### PR TITLE
Feat/rule attributes

### DIFF
--- a/src/AttributeValidatorTrait.php
+++ b/src/AttributeValidatorTrait.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2020 Karmabunny
+ */
+
+namespace karmabunny\kb;
+
+use Exception;
+
+/**
+ * Provide support for rules validation with inline (PHP 8) attributes.
+ *
+ * @see RulesValidator
+ * @see Rule
+ *
+ * @package karmabunny\kb
+ */
+trait AttributeValidatorTrait
+{
+
+    /**
+     * Validate this scenario (or default).
+     *
+     * This will throw if invalid or pass silently if valid.
+     *
+     * @param string|null $scenario null for default.
+     * @return void
+     * @throws Exception
+     * @throws ValidationException
+     */
+    public function validate(string $scenario = null) {
+        $errors = $this->valid($scenario);
+        if ($errors !== true) {
+            throw (new ValidationException)->addErrors($errors);
+        }
+    }
+
+
+    /**
+     * Validate this scenario (or default).
+     *
+     * @param string|null $scenario null for default.
+     * @return array|true True if valid, errors array if invalid.
+     * @throws Exception
+     */
+    public function valid(string $scenario = null)
+    {
+        $valid = new AttributesValidator($this, $scenario);
+
+        if (!$valid->validate()) {
+            return $valid->getErrors();
+        }
+        return true;
+    }
+}

--- a/src/AttributesValidator.php
+++ b/src/AttributesValidator.php
@@ -22,6 +22,9 @@ class AttributesValidator implements Validator
     /** @var object */
     public $target;
 
+    /** @var string|null */
+    public $scenario = null;
+
     /** @var string */
     public $validity = Validity::class;
 
@@ -32,10 +35,12 @@ class AttributesValidator implements Validator
     /**
      *
      * @param object $target
+     * @param string|null $scenario
      */
-    public function __construct(object $target)
+    public function __construct(object $target, string $scenario = null)
     {
         $this->target = $target;
+        $this->scenario = $scenario;
     }
 
 

--- a/src/AttributesValidator.php
+++ b/src/AttributesValidator.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2020 Karmabunny
+ */
+
+namespace karmabunny\kb;
+
+use InvalidArgumentException;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Rules based validation processor.
+ *
+ * @package karmabunny\kb
+ */
+class AttributesValidator implements Validator
+{
+
+    /** @var object */
+    public $target;
+
+    /** @var string */
+    public $validity = Validity::class;
+
+    /** @var array */
+    protected $errors = [];
+
+
+    /**
+     *
+     * @param object $target
+     */
+    public function __construct(object $target)
+    {
+        $this->target = $target;
+    }
+
+
+    /**
+     * Set the validity helper.
+     *
+     * @param string $class
+     */
+    public function setValidity(string $class)
+    {
+        if (!class_exists($class)) {
+            throw new InvalidArgumentException("Invalid validity class: {$class}");
+        }
+
+        $this->validity = $class;
+    }
+
+
+    /** @inheritdoc */
+    public function validate(): bool
+    {
+        $reflect = new ReflectionClass($this->target);
+        $properties = $reflect->getProperties(ReflectionMethod::IS_PUBLIC);
+
+        foreach ($properties as $property) {
+
+            // Parse attributes, if available.
+            if (PHP_VERSION_ID > 80000) {
+                $attributes = $property->getAttributes(Rule::class);
+
+                foreach ($attributes as $attribute) {
+                    /** @var Rule $rule */
+                    $rule = $attribute->newInstance();
+                    $this->process($property->getName(), $rule);
+                }
+            }
+
+            // Also process doc tags.
+            $rules = Rule::parseDoc($property->getDocComment() ?: '');
+
+            foreach ($rules as $rule) {
+                $this->process($property->getName(), $rule);
+            }
+        }
+
+        return empty($this->errors);
+    }
+
+
+    /**
+     *
+     * @param string $name property
+     * @param Rule $rule
+     * @return void
+     */
+    protected function process(string $name, Rule $rule)
+    {
+        try {
+            $value = $this->target->{$name};
+
+            $empty = (
+                $value === null
+                or RulesValidator::isEmpty($value)
+            );
+
+            // Special handling for this one.
+            if ($rule->name === 'required') {
+                if ($empty) {
+                    throw new RequiredFieldException('This field is required');
+                }
+
+                // Otherwise fine.
+                return null;
+            }
+
+            // Skip validation if empty/null.
+            if ($empty) {
+                return null;
+            }
+
+            // Check the local namespace first.
+            if (method_exists($this->target, $rule->name)) {
+                $func = [$this->target, $rule->name];
+            }
+            // Or use the validity helper.
+            else {
+                $func = [$this->validity, $rule->name];
+            }
+
+            // Give-er a check.
+            if (!is_callable($func)) {
+                throw new InvalidArgumentException("Invalid rule: {$rule->name}");
+            }
+
+            // Call it!
+            return $func($value, ...$rule->args);
+        }
+        catch (RequiredFieldException $exception) {
+            $this->errors[$name]['required'] = $exception->getMessage();
+        }
+        catch (ValidationException $exception) {
+            $this->errors[$name][] = $exception->getMessage();
+        }
+    }
+
+
+    /** @inheritdoc */
+    public function hasErrors(): bool
+    {
+        return !empty($this->errors);
+    }
+
+
+    /** @inheritdoc */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/AttributesValidator.php
+++ b/src/AttributesValidator.php
@@ -72,6 +72,26 @@ class AttributesValidator implements Validator
                 continue;
             }
 
+            // Related scenarios for just this rule.
+            $scenarios = Scenario::parseReflector($rule->reflect);
+
+            // Insert a default scenario.
+            if (empty($scenarios)) {
+                $scenarios[] = new Scenario();
+            }
+
+            $ok = false;
+
+            foreach ($scenarios as $scenario) {
+                if ($scenario->name === $this->scenario) {
+                    $ok = true;
+                    break;
+                }
+            }
+
+            // Skip validations if not scenario matches.
+            if (!$ok) continue;
+
             $this->process($rule);
         }
 

--- a/src/RequiredFieldException.php
+++ b/src/RequiredFieldException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2020 Karmabunny
+ */
+
+namespace karmabunny\kb;
+
+use Exception;
+
+/**
+ * Errors from required fields.
+ *
+ * @package karmabunny\kb
+ */
+class RequiredFieldException extends ValidationException
+{
+}

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2020 Karmabunny
+ */
+
+namespace karmabunny\kb;
+
+use Attribute;
+use InvalidArgumentException;
+
+/**
+ * This represents a single rule for a property.
+ *
+ * @package karmabunny\kb
+ */
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+class Rule
+{
+
+    /** @var string */
+    public $name;
+
+    /** @var array */
+    public $args = [];
+
+
+    /**
+     *
+     * @param string $rule
+     * @param array $args
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public function __construct(string $rule, array $args = [])
+    {
+        $this->name = $rule;
+        $this->args = $args;
+    }
+
+
+    /**
+     * Create a set of rules from a doc comment.
+     *
+     * This parses a '@rule' tag.
+     *
+     * @param string $doc
+     * @return self[]
+     */
+    public static function parseDoc(string $doc): array
+    {
+        $tags = Reflect::getDocTags($doc, ['rule']);
+        $tags = $tags['rule'];
+
+        $rules = [];
+
+        foreach ($tags as $tag) {
+            [$rule, $args] = explode(' ', $tag, 2) + [null, null];
+
+            $args = explode(' ', $args);
+            $args = array_map('trim', $args);
+
+            $rules[] = new self($rule, $args);
+        }
+
+        return $rules;
+    }
+}

--- a/src/Scenario.php
+++ b/src/Scenario.php
@@ -12,10 +12,11 @@ use InvalidArgumentException;
 /**
  * This adds a scenario to an existing attribute rule.
  *
+ * @attribute scenario property
  * @package karmabunny\kb
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
-class Scenario
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+class Scenario extends AttributeTag
 {
 
     /** @var string|null */
@@ -34,26 +35,10 @@ class Scenario
     }
 
 
-    /**
-     * Create a set of scenarios from a doc comment.
-     *
-     * This parses a '@scenario' tag.
-     *
-     * @param string $doc
-     * @return self[]
-     */
-    public static function parseDoc(string $doc): array
+    /** @inheritdoc */
+    protected static function build(string $args)
     {
-        $tags = Reflect::getDocTags($doc, ['scenario']);
-        $tags = $tags['scenario'];
-
-        $scenarios = [];
-
-        foreach ($tags as $tag) {
-            $tag = trim($tag) ?: null;
-            $scenarios[] = new self($tag);
-        }
-
-        return $scenarios;
+        return new static(trim($args) ?: null);
     }
+
 }

--- a/src/Scenario.php
+++ b/src/Scenario.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2020 Karmabunny
+ */
+
+namespace karmabunny\kb;
+
+use Attribute;
+use InvalidArgumentException;
+
+/**
+ * This adds a scenario to an existing attribute rule.
+ *
+ * @package karmabunny\kb
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Scenario
+{
+
+    /** @var string|null */
+    public $name;
+
+
+    /**
+     *
+     * @param string|null $name
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public function __construct(string $name = null)
+    {
+        $this->name = $name;
+    }
+
+
+    /**
+     * Create a set of scenarios from a doc comment.
+     *
+     * This parses a '@scenario' tag.
+     *
+     * @param string $doc
+     * @return self[]
+     */
+    public static function parseDoc(string $doc): array
+    {
+        $tags = Reflect::getDocTags($doc, ['scenario']);
+        $tags = $tags['scenario'];
+
+        $scenarios = [];
+
+        foreach ($tags as $tag) {
+            $tag = trim($tag) ?: null;
+            $scenarios[] = new self($tag);
+        }
+
+        return $scenarios;
+    }
+}

--- a/tests/AttributeValidatorTest.php
+++ b/tests/AttributeValidatorTest.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2020 Karmabunny
+ */
+
+use karmabunny\kb\AttributeValidatorTrait;
+use karmabunny\kb\Collection;
+use karmabunny\kb\Rule;
+use karmabunny\kb\Validates;
+use karmabunny\kb\ValidationException;
+use PHPUnit\Framework\TestCase;
+
+
+class AttributeValidatorTest extends TestCase
+{
+    public function testEmpty()
+    {
+        try {
+            $thing = new AttrThing([]);
+            $thing->validate();
+
+            $this->fail('Expected ValidationException.');
+        }
+        catch (ValidationException $exception) {
+            $expected = [
+                'id',
+                'amount',
+            ];
+
+            if (PHP_VERSION_ID >= 80000) {
+                $expected[] = 'php8';
+            }
+
+            $actual = array_keys($exception->errors);
+            $this->assertEquals($expected, $actual);
+
+            $this->assertTrue(isset($exception->errors['id']['required']));
+            $this->assertTrue(isset($exception->errors['amount']['required']));
+        }
+    }
+
+
+    public function testValid()
+    {
+        try {
+            $thing = new AttrThing([
+                'id' => -1234,
+
+                // positiveInt
+                'amount' => 400,
+
+                // range - 10-20
+                'ten_twenty' => 13,
+
+                // range - 20-30
+                'twenty_thirty' => 26,
+
+                // email + end in karmabunny.com.au
+                'address' => 'aaaa@karmabunny.com.au',
+
+                // Not tested in PHP7
+                'php8' => 'test@example.com',
+            ]);
+
+            $thing->validate();
+            $this->assertTrue(true);
+        }
+        catch (ValidationException $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+
+
+    public function testFailure()
+    {
+        try {
+            $thing = new AttrThing([
+                'id' => false,
+
+                // positiveInt
+                'amount' => -400,
+
+                // range - 10-20
+                'ten_twenty' => -13,
+
+                // range - 20-30
+                'twenty_thirty' => 31,
+
+                // email, matchDomain
+                'address' => 'eeeeee',
+            ]);
+
+            $thing->validate();
+
+            $this->fail('Expected ValidationException.');
+        }
+        catch (ValidationException $exception) {
+            $expected = [
+                'id',
+                'amount',
+                'ten_twenty',
+                'twenty_thirty',
+                'address',
+            ];
+
+            if (PHP_VERSION_ID >= 80000) {
+                $expected[] = 'php8';
+            }
+
+            $actual = array_keys($exception->errors);
+            $this->assertEquals($expected, $actual);
+
+            $this->assertTrue(isset($exception->errors['id']['required']));
+            $this->assertCount(1, $exception->errors['amount'] ?? []);
+            $this->assertCount(1, $exception->errors['ten_twenty'] ?? []);
+            $this->assertCount(1, $exception->errors['twenty_thirty'] ?? []);
+            $this->assertCount(2, $exception->errors['address'] ?? []);
+        }
+    }
+
+
+    /**
+     *
+     * @requires PHP >= 8.0
+     */
+    public function testAttributes()
+    {
+        $thing = new AttrThing([
+            'id' => 100,
+            'amount' => 400,
+            'ten_twenty' => 13,
+            'twenty_thirty' => 26,
+            'address' => 'aaaa@karmabunny.com.au',
+        ]);
+
+        // test valid.
+        try {
+            $thing->php8 = 'test@example.com';
+
+            $thing->validate();
+            $this->assertTrue(true);
+        }
+        catch (ValidationException $exception) {
+            $this->fail($exception->getMessage());
+        }
+
+        // test required.
+        try {
+            $thing->php8 = null;
+
+            $thing->validate();
+            $this->fail('Expected ValidationException.');
+        }
+        catch (ValidationException $exception) {
+            $this->assertTrue(isset($exception->errors['php8']['required']));
+        }
+
+        // test invalid.
+        try {
+            $thing->php8 = 'eee';
+
+            $thing->validate();
+            $this->fail('Expected ValidationException.');
+        }
+        catch (ValidationException $exception) {
+            $this->assertCount(3, $exception->errors['php8'] ?? []);
+        }
+    }
+}
+
+
+class AttrThing extends Collection implements Validates
+{
+    use AttributeValidatorTrait;
+
+    /**
+     * @var int
+     * @rule required
+     */
+    public $id;
+
+    /**
+     * @var float|null
+     * @rule positiveInt
+     * @rule required
+     */
+    public $amount;
+
+    /**
+     * @var int
+     * @rule required
+     */
+    public $default = 333;
+
+    /**
+     * @var int
+     * @rule range 10 20
+     */
+    public $ten_twenty;
+
+    /**
+     * @var int
+     * @rule range 20 30
+     */
+    public $twenty_thirty;
+
+    /**
+     * @var string
+     * @rule email
+     * @rule matchDomain karmabunny.com.au
+     */
+    public $address;
+
+    /** @var string */
+    #[Rule('required')]
+    #[Rule('email')]
+    #[Rule('length', [5, 25])]
+    #[Rule('matchDomain', ['example.com'])]
+    public $php8;
+
+
+    public static function matchDomain($value, string $domain)
+    {
+        $re = '/@' . preg_quote($domain) . '$/';
+
+        if (!preg_match($re, $value)) {
+            throw new ValidationException("Domain must be '{$domain}'.");
+        }
+    }
+}

--- a/tests/AttributeValidatorTest.php
+++ b/tests/AttributeValidatorTest.php
@@ -195,28 +195,28 @@ class AttrThing extends Collection implements Validates
 
     /**
      * @var int
-     * @rule range 10 20
+     * @rule range 10, 20
      */
     public $ten_twenty;
 
     /**
      * @var int
-     * @rule range 20 30
+     * @rule range 20, 30
      */
     public $twenty_thirty;
 
     /**
      * @var string
      * @rule email
-     * @rule matchDomain karmabunny.com.au
+     * @rule matchDomain "karmabunny.com.au"
      */
     public $address;
 
     /** @var string */
     #[Rule('required')]
     #[Rule('email')]
-    #[Rule('length', [5, 25])]
-    #[Rule('matchDomain', ['example.com'])]
+    #[Rule('length', 5, 25)]
+    #[Rule('matchDomain', 'example.com')]
     public $php8;
 
 


### PR DESCRIPTION
Some seriously magical stuff. Instead of defining rules in the `rules()` method, this instead puts the rules _directly_ next to their respective property definitions.

Such as:
```php
public MyModel
{
    /** @var string */
    #[Rule('required')]
    #[Rule('email')]
    public string $address;
}
```

Calling `->validate()` or using the `AttributesValidator` class can then process these into a ValidationException or errors array.

This supports PHP 7 environments with the `@rule` doc tag.

Notes:
- Unsure about calling it a `Rule` - should it be `ValidationRule` or `Validate` ? 
