### PR TITLE
Feat/secrets

### DIFF
--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -295,6 +295,39 @@ class Arrays
 
 
     /**
+     * Filter multi-dimensional arrays.
+     *
+     * Both value and key are always passed to the callback.
+     *
+     * @param array $array
+     * @param callable|null $callback
+     * @param bool $keep_arrays
+     * @return array
+     */
+    public static function filterRecursive(array $array, callable $callback = null, $keep_arrays = false): array
+    {
+        foreach ($array as $key => &$value) {
+            if (is_array($value)) {
+                $value = self::filterRecursive($value, $callback, $keep_arrays);
+
+                // Skip empty checks.
+                if ($keep_arrays) continue;
+            }
+            else if ($callback && $callback($value, $key)) {
+                unset($array[$key]);
+            }
+
+            if (empty($value)) {
+                unset($array[$key]);
+            }
+        }
+        unset($value);
+
+        return $array;
+    }
+
+
+    /**
      * Reduce the array to a subset, as defined by the keys parameter.
      *
      * @param array $array

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -423,12 +423,49 @@ class Arrays
     /**
      * Like `array_map` but includes a 'key' argument.
      *
+     * Key modification can be done with a reference `&$key` argument.
+     *
+     * ```
+     * // Basic usage
+     * Arrays::mapWithKeys($list, fn($item, $key) => $key . $item);
+     *
+     * // OR to modify keys
+     * Arrays::mapWithKeys($list, function($item, &$key) {
+     *     $key = $item->id;
+     *     return $item;
+     * });
+     * ```
+     *
+     * Filter callbacks used with this method can be re-used (without key
+     * modification) for `array_map` or `mapRecursive`.
+     *
+     * @param array $array
+     * @param callable $fn (item, key) => item
+     * @return array
+     */
+    public static function mapWithKeys(array $array, $fn): array
+    {
+        $items = [];
+
+        foreach ($array as $key => $item) {
+            $item = $fn($item, $key);
+            $items[$key] = $item;
+        }
+
+        return $items;
+    }
+
+
+    /**
+     * A weirder version of `mapWithKeys()`.
+     *
+     * Instead this expects the callback to return a key-value pair, e.g.
+     *
      * ```
      * Arrays::mapKeys($list, fn($item, $key) => [$key, $item]);
      * ```
      *
-     * No, this cannot perform a zip.
-     *
+     * @deprecated use mapWithKeys() - what a mess.
      * @param array $array
      * @param callable $fn (item, key) => [key, item]
      * @return array
@@ -451,6 +488,9 @@ class Arrays
      *
      * Caution when using `CHILD_FIRST`; do not map leaves into arrays - you may
      * trigger an infinite recursion.
+     *
+     * Modifying the `$key` callback argument, like `mapWithKeys`, is undefined
+     * behaviour. Best avoid.
      *
      * @param array $array
      * @param callable $fn ($value, $key) => $value

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -299,26 +299,38 @@ class Arrays
      *
      * Both value and key are always passed to the callback.
      *
-     * The default `empty_arrays` setting is implied by the callback:
-     * - If _no_ callback, empty arrays are discard - `empty_arrays = false`
-     * - Otherwise, empty arrays are preserved - `empty_arrays = true`
+     * The default `keep_empty_arrays` setting is implied by the callback:
+     * - If _no_ callback, empty arrays are discard - `keep_empty_arrays = false`
+     * - Otherwise, empty arrays are preserved - `keep_empty_arrays = true`
+     *
+     * Be aware, numeric arrays will not 're-settle' their keys. Items will
+     * retain their index position even with gaps from removed items. This is
+     * the same behaviour as `array_filter`.
+     *
+     * For example:
+     *
+     * ```
+     * $arr = [ 'a', '', 'c' ];
+     * $filtered = array_filter($arr);
+     * // => [ 0 => 'a', 2 => 'c' ]
+     * ```
      *
      * @param array $array
      * @param callable|null $callback
-     * @param bool|null $empty_arrays
+     * @param bool|null $keep_empty_arrays
      * @return array
      */
-    public static function filterRecursive(array $array, callable $callback = null, bool $empty_arrays = null): array
+    public static function filterRecursive(array $array, callable $callback = null, bool $keep_empty_arrays = null): array
     {
-        if ($empty_arrays === null) {
-            $empty_arrays = $callback !== null;
+        if ($keep_empty_arrays === null) {
+            $keep_empty_arrays = ($callback !== null);
         }
 
         foreach ($array as $key => &$value) {
             if (is_array($value)) {
-                $value = self::filterRecursive($value, $callback, $empty_arrays);
+                $value = self::filterRecursive($value, $callback, $keep_empty_arrays);
 
-                if (!$empty_arrays and empty($value)) {
+                if (!$keep_empty_arrays and empty($value)) {
                     unset($array[$key]);
                 }
             }

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -323,7 +323,7 @@ class Arrays
                 }
             }
             else if ($callback) {
-                if ($callback($value, $key)) {
+                if (!$callback($value, $key)) {
                     unset($array[$key]);
                 }
             }

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -299,30 +299,42 @@ class Arrays
      *
      * Both value and key are always passed to the callback.
      *
+     * The default `empty_arrays` setting is implied by the callback:
+     * - If _no_ callback, empty arrays are discard - `empty_arrays = false`
+     * - Otherwise, empty arrays are preserved - `empty_arrays = true`
+     *
      * @param array $array
      * @param callable|null $callback
-     * @param bool $keep_arrays
+     * @param bool|null $empty_arrays
      * @return array
      */
-    public static function filterRecursive(array $array, callable $callback = null, $keep_arrays = false): array
+    public static function filterRecursive(array $array, callable $callback = null, bool $empty_arrays = null): array
     {
+        if ($empty_arrays === null) {
+            $empty_arrays = $callback !== null;
+        }
+
         foreach ($array as $key => &$value) {
             if (is_array($value)) {
-                $value = self::filterRecursive($value, $callback, $keep_arrays);
+                $value = self::filterRecursive($value, $callback, $empty_arrays);
 
-                // Skip empty checks.
-                if ($keep_arrays) continue;
+                if (!$empty_arrays and empty($value)) {
+                    unset($array[$key]);
+                }
             }
-            else if ($callback && $callback($value, $key)) {
-                unset($array[$key]);
+            else if ($callback) {
+                if ($callback($value, $key)) {
+                    unset($array[$key]);
+                }
             }
-
-            if (empty($value)) {
-                unset($array[$key]);
+            else {
+                if (empty($value)) {
+                    unset($array[$key]);
+                }
             }
         }
-        unset($value);
 
+        unset($value);
         return $array;
     }
 

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -207,8 +207,8 @@ class Secrets extends DataObject
             return false;
         }
 
-        // Right?
-        if (strlen($item) == 2) {
+        // What secrets is shorter than 3 chars?
+        if (strlen($item) < 3) {
             return false;
         }
 

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -301,8 +301,8 @@ class Secrets extends DataObject
     {
         $process = function ($value, $key) {
             return (
-                $this->isSecretKey($key)
-                or $this->isSecretValue($value)
+                !$this->isSecretKey($key)
+                and !$this->isSecretValue($value)
             );
         };
 

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -229,13 +229,17 @@ class Secrets extends DataObject
             }
         }
 
+        $hex = preg_match('/^[0-9a-f]+$/i', $item)
+            ? pack('H*', $item)
+            : false;
+
         // Or maybe it's maybelline. Or hex.
-        if (preg_match('/^[0-9a-f]*$/', $item)) {
+        if (is_string($hex) and strlen($hex) > 0) {
             if ($this->hex) {
                 return true;
             }
 
-            if (preg_match($this->value_pattern, pack('H*', $item))) {
+            if (preg_match($this->value_pattern, $hex)) {
                 return true;
             }
         }

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -93,18 +93,11 @@ class Secrets extends DataObject
     public $hex = false;
 
     /**
-     * Create masks no smaller than this.
+     * Create masks with fixed sizes.
      *
-     * @var int
+     * @var int|null
      */
-    public $min_mask = 10;
-
-    /**
-     * Create masks no bigger than this.
-     *
-     * @var int
-     */
-    public $max_mask = 25;
+    public $mask_length = 16;
 
 
     /**
@@ -311,20 +304,11 @@ class Secrets extends DataObject
      * TODO use php8 sensitive attributes here.
      *
      * @param string $value
-     * @return void
+     * @return string
      */
-    protected function getMask(string $value)
+    protected function getMask(string $value): string
     {
-        $length = strlen($value);
-
-        if ($this->min_mask) {
-            $length = max($this->min_mask, $length);
-        }
-
-        if ($this->max_mask) {
-            $length = min($this->max_mask, $length);
-        }
-
+        $length = $this->mask_length ?: strlen($value);
         return str_repeat('*', $length);
     }
 

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -375,7 +375,7 @@ class Secrets extends DataObject
             return Arrays::mapRecursive($item, $process, Arrays::CHILD_FIRST);
         }
         else {
-            return array_map($process, $item);
+            return Arrays::mapWithKeys($item, $process);
         }
     }
 

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -27,6 +27,7 @@ class Secrets extends DataObject
     const RULE_KEY_CVV = '(?i:cvv|cvn|ccv)';
 
     const RULE_HTTP_AUTH = '^(?i:basic|bearer)\w(.*)';
+    const RULE_HTTP_INLINE = ':\/\/[^:]+:[^@]+@';
     const RULE_JWT = '^eyJ[^.]+\.';
     const RULE_SSH_PGP = '^BEGIN.*PRIVATE KEY';
     const RULE_BYCRYPT_HASH = '^\$2[aby]\$.*\$';
@@ -45,8 +46,10 @@ class Secrets extends DataObject
         self::RULE_KEY_CVV,
     ];
 
+
     const RULE_VALUES = [
         self::RULE_HTTP_AUTH,
+        self::RULE_HTTP_INLINE,
         self::RULE_JWT,
         self::RULE_SSH_PGP,
         self::RULE_BYCRYPT_HASH,

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -349,23 +349,23 @@ class Secrets extends DataObject
      */
     public function mask(array $item, bool $recursive = true): array
     {
-        $process = function (&$value, $key) {
+        $process = function ($value, $key) {
             if ($this->isSecretKey($key)) {
                 $value = $this->getMask($value);
             }
             else if ($this->isSecretValue($value)) {
                 $value = $this->getMask($value);
             }
+
+            return $value;
         };
 
         if ($recursive) {
-            array_walk_recursive($item, $process);
+            return Arrays::mapRecursive($item, $process);
         }
         else {
-            array_walk($item, $process);
+            return array_map($process, $item);
         }
-
-        return $item;
     }
 
 

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2020 Karmabunny
+ */
+
+namespace karmabunny\kb;
+
+
+/**
+ * Identify secrets in strings.
+ *
+ * Mask or remove them.
+ * Whatever you like.
+ *
+ * @link https://github.com/Yelp/detect-secrets/
+ * @package karmabunny\kb
+ */
+class Secrets extends DataObject
+{
+    use UpdateTidyTrait;
+
+    const RULE_KEY_PASSWORD = '(?i:password|passwd)';
+    const RULE_KEY_SECRET = '(?:ikey|secret)';
+    const RULE_KEY_TOKEN = '(?:itoken|salt|nonce)';
+    const RULE_KEY_CVV = '(?:icvv|cvn|ccv)';
+
+    const RULE_HTTP_AUTH = '^(?:ibasic|bearer)';
+    const RULE_JWT = '^eyJ[^.]\.';
+    const RULE_SSH_PGP = '^BEGIN.*PRIVATE KEY';
+    const RULE_BYCRYPT_HASH = '^\$2[aby]\$..*\$';
+    const RULE_GITHUB = '^(?:ghp|gho|ghu|ghs|ghr)';
+    const RULE_AWS = '^AKIA[0-9A-Z]{16}';
+    const RULE_AWS_KEY = '^aws.{0,20}(?:key|pwd|pw|password|pass|token)';
+    const RULE_SENDGRID = '^SG\..{22}\..{43}';
+    const RULE_SQUARE = '^sq0csp-';
+    const RULE_STRIPE = '^[rs]k_live';
+
+
+    const RULE_KEYS = [
+        self::RULE_KEY_PASSWORD,
+        self::RULE_KEY_SECRET,
+        self::RULE_KEY_TOKEN,
+        self::RULE_KEY_CVV,
+    ];
+
+    const RULE_VALUES = [
+        self::RULE_HTTP_AUTH,
+        self::RULE_JWT,
+        self::RULE_SSH_PGP,
+        self::RULE_BYCRYPT_HASH,
+        self::RULE_GITHUB,
+        self::RULE_AWS,
+        self::RULE_AWS_KEY,
+        self::RULE_SENDGRID,
+        self::RULE_SQUARE,
+        self::RULE_STRIPE,
+    ];
+
+
+    /** @var string */
+    public $key_pattern;
+
+    /** @var string */
+    public $value_pattern;
+
+    /**
+     * Whether to treat _all_ base64 strings as secrets.
+     *
+     * If not enabled, base64 strings that contain matching patterns are
+     * still removed.
+     *
+     * If enabled, all base64 strings are removed.
+     *
+     * Default: false.
+     *
+     * @var bool
+     */
+    public $base64 = false;
+
+    /**
+     * Whether to treat _all_ hex strings as secrets.
+     *
+     * If not enabled, hex strings that contain matching patterns are
+     * still removed.
+     *
+     * If enabled, all hex strings are removed.
+     *
+     * Default: false.
+     *
+     * @var bool
+     */
+    public $hex = false;
+
+    /**
+     * Create masks no smaller than this.
+     *
+     * @var int
+     */
+    public $min_mask = 10;
+
+    /**
+     * Create masks no bigger than this.
+     *
+     * @var int
+     */
+    public $max_mask = 25;
+
+
+    /**
+     * Shorthand, create a sanitizer using the builtin rules.
+     *
+     * @param array $config override settings
+     * @return Secrets
+     */
+    public static function create(array $config = [])
+    {
+        $config = array_merge([
+            'key_rules' => self::RULE_KEYS,
+            'value_rules' => self::RULE_VALUES,
+        ], $config);
+
+        return new self($config);
+    }
+
+
+    /** @inheritdoc */
+    public function update($config)
+    {
+        parent::update($config);
+
+        if ($rules = $config['key_rules'] ?? null) {
+            $this->key_pattern = static::buildPattern($rules);
+        }
+
+        if ($rules = $config['value_rules'] ?? null) {
+            $this->value_pattern = static::buildPattern($rules);
+        }
+    }
+
+
+    /**
+     * Does this key identify a secret?
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public function isSecretKey($item): bool
+    {
+        if (!is_string($item)) {
+            return false;
+        }
+
+        if (empty($item)) {
+            return false;
+        }
+
+        if (preg_match($this->key_pattern, $item)) {
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Does this value look like a secret?
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public function isSecretValue($item): bool
+    {
+        if (!is_string($item)) {
+            return false;
+        }
+
+        if (empty($item)) {
+            return false;
+        }
+
+        // Right?
+        if (strlen($item) == 2) {
+            return false;
+        }
+
+        if (preg_match($this->value_pattern, $item)) {
+            return true;
+        }
+
+        // Maybe it's a base64 string.
+        $base64 = base64_decode($item, false);
+
+        if ($base64) {
+            if ($this->base64) {
+                return true;
+            }
+
+            if (preg_match($this->value_pattern, $base64)) {
+                return true;
+            }
+        }
+
+        // Or maybe it's maybelline. Or hex.
+        if (preg_match('/^[0-9a-f]*$/', $item)) {
+            if ($this->hex) {
+                return true;
+            }
+
+            if (preg_match($this->value_pattern, pack('H*', $item))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Does this item look like a secret, either key or value?
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public function isSecret($item): bool
+    {
+        if (!is_string($item)) return false;
+        return $this->isSecretKey($item) or $this->isSecretValue($item);
+    }
+
+
+    /**
+     * Mask any secrets in the given array.
+     *
+     * Note, recursive mode cannot dive into objects.
+     *
+     * @param array $item
+     * @param bool $recursive
+     * @return array
+     */
+    public function mask(array $item, bool $recursive = true): array
+    {
+        $process = function (&$value, $key) {
+            if ($this->isSecretKey($key)) {
+                $value = $this->getMask($value);
+            }
+
+            if ($this->isSecretValue($value)) {
+                $value = $this->getMask($value);
+            }
+        };
+
+        if ($recursive) {
+            array_walk_recursive($item, $process);
+        }
+        else {
+            array_walk($item, $process);
+        }
+
+        return $item;
+    }
+
+
+    /**
+     * Remove any secrets in the given array.
+     *
+     * Note, recursive mode cannot dive into objects.
+     *
+     * @param array $item
+     * @param bool $recursive - process nested arrays
+     * @return array
+     */
+    public function clean(array $item, bool $recursive = true): array
+    {
+        if ($recursive) {
+            $arrayIterator = new \RecursiveArrayIterator($item);
+            $recursiveIterator = new \RecursiveIteratorIterator($arrayIterator, \RecursiveIteratorIterator::SELF_FIRST);
+
+            foreach ($recursiveIterator as $key => $value) {
+                // TODO none of this works...
+                if ($this->isSecretKey($key)) {
+                    $arrayIterator->offsetUnset($key);
+                }
+
+                if ($this->isSecretValue($value)) {
+                    $arrayIterator->offsetUnset($key);
+                }
+            }
+
+            return $arrayIterator->getArrayCopy();
+        }
+        else {
+            foreach ($item as $key => $value) {
+                if ($this->isSecretKey($key)) {
+                    unset($item[$key]);
+                }
+
+                if ($this->isSecretValue($value)) {
+                    unset($item[$key]);
+                }
+            }
+
+            return $item;
+        }
+    }
+
+
+    /**
+     * Create a masked version of the value.
+     *
+     * TODO use php8 sensitive attributes here.
+     *
+     * @param string $value
+     * @return void
+     */
+    protected function getMask(string $value)
+    {
+        $length = strlen($value);
+
+        if ($this->min_mask) {
+            $length = max($this->min_mask, $length);
+        }
+
+        if ($this->max_mask) {
+            $length = min($this->max_mask, $length);
+        }
+
+        return str_repeat('*', $length);
+    }
+
+
+    /**
+     * Build a regex pattern (partial) from a list of rules.
+     *
+     * @param array $rules
+     * @param string $delimiter
+     * @return string
+     */
+    protected function buildPattern(array $rules, string $delimiter = '/')
+    {
+        return $delimiter . '(' . implode('|', $rules) . ')' . $delimiter;
+    }
+
+}

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -31,12 +31,12 @@ class Secrets extends DataObject
 
     const RULE_KEY_PASSWORD = '(?i:password|passwd)';
     const RULE_KEY_SECRET = '(?i:key|secret)';
-    const RULE_KEY_TOKEN = '(?i:token|salt|nonce)';
+    const RULE_KEY_TOKEN = '(?i:token|salt|nonce|jwt)';
     const RULE_KEY_CVV = '(?i:cvv|cvn|ccv)';
 
     const RULE_HTTP_AUTH = '^(?i:basic|bearer)\w(.*)';
     const RULE_HTTP_INLINE = ':\/\/[^:]+:[^@]+@';
-    const RULE_JWT = '^eyJ[^.]+\.';
+    const RULE_JWT = '^eyJ[^.]+\..';
     const RULE_SSH_PGP = '^BEGIN.*PRIVATE KEY';
     const RULE_BYCRYPT_HASH = '^\$2[aby]\$.*\$';
     const RULE_GITHUB = '^(?:ghp|gho|ghu|ghs|ghr)';

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -207,7 +207,7 @@ class Secrets extends DataObject
             return false;
         }
 
-        // What secrets is shorter than 3 chars?
+        // What secret is shorter than 3 chars?
         if (strlen($item) < 3) {
             return false;
         }

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -58,6 +58,12 @@ class Secrets extends DataObject
     ];
 
 
+    /** @var string[] */
+    public $key_rules;
+
+    /** @var string[] */
+    public $value_rules;
+
     /** @var string */
     public $key_pattern;
 
@@ -108,11 +114,8 @@ class Secrets extends DataObject
      */
     public static function create(array $config = [])
     {
-        $config = array_merge([
-            'key_rules' => self::RULE_KEYS,
-            'value_rules' => self::RULE_VALUES,
-        ], $config);
-
+        $config['key_rules'] = $config['key_rules'] ?? self::RULE_KEYS;
+        $config['value_rules'] = $config['value_rules'] ?? self::RULE_VALUES;
         return new self($config);
     }
 
@@ -121,14 +124,32 @@ class Secrets extends DataObject
     public function update($config)
     {
         parent::update($config);
+        $this->key_pattern = $this->buildPattern($this->key_rules);
+        $this->value_pattern = $this->buildPattern($this->value_rules);
+    }
 
-        if ($rules = $config['key_rules'] ?? null) {
-            $this->key_pattern = static::buildPattern($rules);
-        }
 
-        if ($rules = $config['value_rules'] ?? null) {
-            $this->value_pattern = static::buildPattern($rules);
-        }
+    /**
+     *
+     * @param string $pattern
+     * @return void
+     */
+    public function addKeyRule(string $pattern)
+    {
+        $this->key_rules[] = $pattern;
+        $this->key_pattern = $this->buildPattern($this->key_rules);
+    }
+
+
+    /**
+     *
+     * @param string $pattern
+     * @return void
+     */
+    public function addValueRule(string $pattern)
+    {
+        $this->value_rules[] = $pattern;
+        $this->value_pattern = static::buildPattern($this->value_rules);
     }
 
 

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -256,8 +256,23 @@ class Secrets extends DataObject
      */
     public function isSecret($item): bool
     {
-        if (!is_string($item)) return false;
-        return $this->isSecretKey($item) or $this->isSecretValue($item);
+        if (!is_string($item)) {
+            return false;
+        }
+
+        if (empty($item)) {
+            return false;
+        }
+
+        if ($this->isSecretKey($item)) {
+            return true;
+        }
+
+        if ($this->isSecretValue($item)) {
+            return true;
+        }
+
+        return false;
     }
 
 

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -13,6 +13,14 @@ namespace karmabunny\kb;
  * Mask or remove them.
  * Whatever you like.
  *
+ * This comes preloaded with a set of rules to help you tidy up your mess.
+ *
+ * Best use case:
+ *
+ * ```
+ * $safe = Secrets::create()->mask($_POST);
+ * ```
+ *
  * @link https://github.com/Yelp/detect-secrets/
  * @package karmabunny\kb
  */
@@ -134,8 +142,9 @@ class Secrets extends DataObject
 
 
     /**
+     * Add a new key rule.
      *
-     * @param string $pattern
+     * @param string $pattern regex
      * @return void
      */
     public function addKeyRule(string $pattern)
@@ -146,8 +155,9 @@ class Secrets extends DataObject
 
 
     /**
+     * Add a new value rule.
      *
-     * @param string $pattern
+     * @param string $pattern regex
      * @return void
      */
     public function addValueRule(string $pattern)

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -314,15 +314,15 @@ class Secrets extends DataObject
 
 
     /**
-     * Build a regex pattern (partial) from a list of rules.
+     * Build a regex pattern from a list of rules.
      *
      * @param array $rules
      * @param string $delimiter
      * @return string
      */
-    protected function buildPattern(array $rules, string $delimiter = '/')
+    protected function buildPattern(array $rules, string $delimiter = '/'): string
     {
-        return $delimiter . '(' . implode('|', $rules) . ')' . $delimiter;
+        return $delimiter . '(?:' . implode('|', $rules) . ')' . $delimiter;
     }
 
 }

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -20,15 +20,16 @@ class Secrets extends DataObject
 {
     use UpdateTidyTrait;
 
-    const RULE_KEY_PASSWORD = '(?i:password|passwd)';
-    const RULE_KEY_SECRET = '(?:ikey|secret)';
-    const RULE_KEY_TOKEN = '(?:itoken|salt|nonce)';
-    const RULE_KEY_CVV = '(?:icvv|cvn|ccv)';
 
-    const RULE_HTTP_AUTH = '^(?:ibasic|bearer)';
-    const RULE_JWT = '^eyJ[^.]\.';
+    const RULE_KEY_PASSWORD = '(?i:password|passwd)';
+    const RULE_KEY_SECRET = '(?i:key|secret)';
+    const RULE_KEY_TOKEN = '(?i:token|salt|nonce)';
+    const RULE_KEY_CVV = '(?i:cvv|cvn|ccv)';
+
+    const RULE_HTTP_AUTH = '^(?i:basic|bearer)\w(.*)';
+    const RULE_JWT = '^eyJ[^.]+\.';
     const RULE_SSH_PGP = '^BEGIN.*PRIVATE KEY';
-    const RULE_BYCRYPT_HASH = '^\$2[aby]\$..*\$';
+    const RULE_BYCRYPT_HASH = '^\$2[aby]\$.*\$';
     const RULE_GITHUB = '^(?:ghp|gho|ghu|ghs|ghr)';
     const RULE_AWS = '^AKIA[0-9A-Z]{16}';
     const RULE_AWS_KEY = '^aws.{0,20}(?:key|pwd|pw|password|pass|token)';

--- a/src/Url.php
+++ b/src/Url.php
@@ -254,6 +254,7 @@ class Url extends DataObject
      *
      * @param string $url
      * @return self
+     * @throws UrlParseException
      */
     public static function parse(string $url)
     {

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -234,7 +234,7 @@ final class ArraysTest extends TestCase {
         ];
 
         $actual = Arrays::filterRecursive($array, function($item) {
-            return is_int($item);
+            return !is_int($item);
         });
 
         $this->assertEquals($expected, $actual);

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -329,6 +329,32 @@ final class ArraysTest extends TestCase {
         $this->assertEquals($expected, $actual);
     }
 
+
+
+    public function testMapWithKeys()
+    {
+        $array = [
+            'aaa' => 123,
+            'xxx' => 567,
+            'zzz' => 789,
+        ];
+
+        $expected = [
+            'prefix_aaa' => 'aaa123',
+            'prefix_xxx' => 'xxx567',
+            'prefix_zzz' => 'zzz789',
+        ];
+
+        $actual = Arrays::mapWithKeys($array, function($item, &$key) {
+            $item = $key . $item;
+            $key = 'prefix_' . $key;
+            return $item;
+        });
+
+        $this->assertEquals($expected, $actual);
+    }
+
+
     public function testMapRecursive()
     {
         $array = [

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -169,6 +169,78 @@ final class ArraysTest extends TestCase {
     }
 
 
+    public function testFilterRecursive()
+    {
+        $array = [
+            'item1' => [
+                'nested1' => 123,
+                'nested2' => 0,
+                'nested3' => null,
+                'nested4' => 567,
+                'deeper' => [
+                    'deepest' => 'abc',
+                ],
+            ],
+            'item2' => [],
+            'item3' => [
+                'empty1' => null,
+                'empty2' => null,
+            ],
+        ];
+
+        // Standard filter, discard arrays.
+        $expected = [
+            'item1' => [
+                'nested1' => 123,
+                'nested4' => 567,
+                'deeper' => [
+                    'deepest' => 'abc',
+                ],
+            ],
+        ];
+
+        $actual = Arrays::filterRecursive($array);
+        $this->assertEquals($expected, $actual);
+
+        // Standard filter, keep arrays.
+        $expected = [
+            'item1' => [
+                'nested1' => 123,
+                'nested4' => 567,
+                'deeper' => [
+                    'deepest' => 'abc',
+                ],
+            ],
+            'item2' => [],
+            'item3' => [],
+        ];
+
+        $actual = Arrays::filterRecursive($array, null, true);
+        $this->assertEquals($expected, $actual);
+
+        // A filter that removes integers.
+        $expected = [
+            'item1' => [
+                'nested3' => null,
+                'deeper' => [
+                    'deepest' => 'abc',
+                ],
+            ],
+            'item2' => [],
+            'item3' => [
+                'empty1' => null,
+                'empty2' => null,
+            ],
+        ];
+
+        $actual = Arrays::filterRecursive($array, function($item) {
+            return is_int($item);
+        });
+
+        $this->assertEquals($expected, $actual);
+    }
+
+
     public function testFilterKeys()
     {
         $array = [

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -20,15 +20,27 @@ const DATA = [
 
     'basic_auth' => 'http://username:whywouldyouusehttpforpasswords@example.com',
 
+    'badly_named_aws_bits' => 'AKIAIOSFODNN7EXAMPLE',
+
     'aws_access_key' => 'AKIAIOSFODNN7EXAMPLE',
     'aws_secret_access_key' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
 
     'stripe' => [
         'key' => 'sk_liveetcetcetc',
-        'publishable' => 'pk_livenot-a-problem',
+        'publishable' => 'pk_live-not-a-problem',
 
         'alternatively' => [
             'hash' => '$2y$eyyoooo$',
+            'password' => 'plaintext omg',
+            'cvv' => '555',
+            'token' => 'lots of these',
+            'list' => [
+                'ghp_asdfasdf',
+                'eyJ44444444444.11111111',
+                'sq0csp-1234567890',
+                'aws.1111token',
+                'SG.1111122222333334444455.1111122222333334444455555666667777788888999'
+            ],
         ],
     ],
 ];
@@ -44,9 +56,8 @@ class SecretsTest extends TestCase
     public function testKeys()
     {
         $secrets = Secrets::create();
-
         $this->assertFalse($secrets->isSecretKey('red_herring'));
-        $this->assertFalse($secrets->isSecretKey('aws_access_key'));
+        $this->assertFalse($secrets->isSecretKey('badly_named_aws_bits'));
         $this->assertTrue($secrets->isSecretKey('aws_secret_access_key'));
     }
 
@@ -54,9 +65,8 @@ class SecretsTest extends TestCase
     public function testValues()
     {
         $secrets = Secrets::create();
-
         $this->assertFalse($secrets->isSecretValue(DATA['red_herring']));
-        $this->assertTrue($secrets->isSecretValue(DATA['aws_access_key']));
+        $this->assertTrue($secrets->isSecretValue(DATA['badly_named_aws_bits']));
         $this->assertFalse($secrets->isSecretValue(DATA['aws_secret_access_key']));
     }
 
@@ -93,18 +103,29 @@ class SecretsTest extends TestCase
         $expected = [
             'red_herring' => 'DEADBEEF',
             'id' => 'YW1pYWx3YXlzZ2VuZXJhdGluZ3BheWxvYWRzd2hlbmltaHVuZ3J5b3JhbWlhbHdheXNodW5ncnk',
-            'base64_secret' => '*************************',
-            'base64_sub_secret' => '*************************',
-            'hex_secret' => '*************************',
-            'hex_sub_secret' => '*************************',
-            'basic_auth' => 'http://username:whywouldyouusehttpforpasswords@example.com',
-            'aws_access_key' => '********************',
-            'aws_secret_access_key' => '*************************',
+            'base64_secret' => '****************',
+            'base64_sub_secret' => '****************',
+            'hex_secret' => '****************',
+            'hex_sub_secret' => '****************',
+            'basic_auth' => '****************',
+            'badly_named_aws_bits' => '****************',
+            'aws_access_key' => '****************',
+            'aws_secret_access_key' => '****************',
             'stripe' => [
                 'key' => '****************',
-                'publishable' => 'pk_livenot-a-problem',
+                'publishable' => 'pk_live-not-a-problem',
                 'alternatively' => [
-                    'hash' => '************',
+                    'hash' => '****************',
+                    'password' => '****************',
+                    'cvv' => '****************',
+                    'token' => '****************',
+                    'list' => [
+                        '****************',
+                        '****************',
+                        '****************',
+                        '****************',
+                        '****************'
+                    ],
                 ],
             ],
         ];
@@ -115,8 +136,6 @@ class SecretsTest extends TestCase
 
     public function testClean()
     {
-        $this->markTestSkipped('recursive mode is unfinished');
-
         $input = DATA;
 
         $secrets = Secrets::create();
@@ -125,10 +144,10 @@ class SecretsTest extends TestCase
         $expected = [
             'red_herring' => 'DEADBEEF',
             'id' => 'YW1pYWx3YXlzZ2VuZXJhdGluZ3BheWxvYWRzd2hlbmltaHVuZ3J5b3JhbWlhbHdheXNodW5ncnk',
-            'basic_auth' => 'http://username:whywouldyouusehttpforpasswords@example.com',
             'stripe' => [
-                'publishable' => 'pk_livenot-a-problem',
+                'publishable' => 'pk_live-not-a-problem',
                 'alternatively' => [
+                    'list' => [],
                 ],
             ],
         ];

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -67,9 +67,18 @@ class SecretsTest extends TestCase
     public function testValues()
     {
         $secrets = Secrets::create();
-        $this->assertFalse($secrets->isSecretValue(DATA['red_herring']));
-        $this->assertTrue($secrets->isSecretValue(DATA['badly_named_aws_bits']));
-        $this->assertFalse($secrets->isSecretValue(DATA['aws_secret_access_key']));
+
+        $actual = $secrets->isSecretValue(DATA['red_herring']);
+        $this->assertFalse($actual, DATA['red_herring']);
+
+        $actual = $secrets->isSecretValue(DATA['badly_named_aws_bits']);
+        $this->assertTrue($actual, DATA['badly_named_aws_bits']);
+
+        $actual = $secrets->isSecretValue(DATA['aws_secret_access_key']);
+        $this->assertFalse($actual, DATA['aws_secret_access_key']);
+
+        $actual = $secrets->isSecretValue(DATA['jks_empty']);
+        $this->assertFalse($actual, DATA['jks_empty']);
     }
 
 

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -258,6 +258,20 @@ class SecretsTest extends TestCase
         ];
 
         $this->assertEquals($expected, $actual);
+
+        $expected2 = $input;
+        $expected2['base64_secret'] = $expected['base64_secret'];
+        $expected2['base64_sub_secret'] = $expected['base64_sub_secret'];
+        $expected2['hex_secret'] = $expected['hex_secret'];
+        $expected2['hex_sub_secret'] = $expected['hex_sub_secret'];
+        $expected2['basic_auth'] = $expected['basic_auth'];
+        $expected2['badly_named_aws_bits'] = $expected['badly_named_aws_bits'];
+        $expected2['aws_access_key'] = $expected['aws_access_key'];
+        $expected2['aws_secret_access_key'] = $expected['aws_secret_access_key'];
+        $expected2['deeply_secret'] = $expected['deeply_secret'];
+
+        $actual = $secrets->mask($input, false);
+        $this->assertEquals($expected2, $actual);
     }
 
 

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -46,14 +46,13 @@ const DATA = [
         ],
     ],
 
-    // This won't match.
-    // TODO But should it?
-    // What would we replace it with?
-    // - a single string - potentially breaks things.
-    // - or replace/clean all strings inside it?
     'deeply_secret' => [
         'field1' => 123,
         'field2' => 'abc',
+        'nested' => [
+            'def',
+            'ghi',
+        ]
     ],
 
     'encoded_things' => [
@@ -240,8 +239,12 @@ class SecretsTest extends TestCase
                 ],
             ],
             'deeply_secret' => [
-                'field1' => 123,
-                'field2' => 'abc',
+                'field1' => '****************',
+                'field2' => '****************',
+                'nested' => [
+                    '****************',
+                    '****************',
+                ]
             ],
             'encoded_things' => [
                 '****************',
@@ -275,10 +278,7 @@ class SecretsTest extends TestCase
                     'list' => [],
                 ],
             ],
-            'deeply_secret' => [
-                'field1' => 123,
-                'field2' => 'abc',
-            ],
+            'deeply_secret' => [],
             'encoded_things' => [
                 4 => 'http://example.com/oauth?error=nothingtoseehere',
                 6 => 'eyJjbGVhbiI6ImFuZCBhYm92ZSBib2FyZCJ9',

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2020 Karmabunny
+ */
+
+use karmabunny\kb\Secrets;
+use PHPUnit\Framework\TestCase;
+
+const DATA = [
+    'red_herring' => 'DEADBEEF',
+    'id' => 'YW1pYWx3YXlzZ2VuZXJhdGluZ3BheWxvYWRzd2hlbmltaHVuZ3J5b3JhbWlhbHdheXNodW5ncnk',
+
+
+    'base64_secret' => 'c2VjcmV0IG1lc3NhZ2Ugc28geW91J2xsIG5ldmVyIGd1ZXNzIG15IHBhc3N3b3Jk',
+    'base64_sub_secret' => 'c2tfbGl2ZTEyMjMxMjNhc2RmYXNkZjEyMzEyMw==',
+
+    'hex_secret' => '8b1118b376c313ed420e5133ba91307817ed52c2',
+    'hex_sub_secret' => '424547494e205253412050524956415445204b45590a61736466617364666173646661736466454e44205253412050524956415445204b45590',
+
+    'basic_auth' => 'http://username:whywouldyouusehttpforpasswords@example.com',
+
+    'aws_access_key' => 'AKIAIOSFODNN7EXAMPLE',
+    'aws_secret_access_key' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+
+    'stripe' => [
+        'key' => 'sk_liveetcetcetc',
+        'publishable' => 'pk_livenot-a-problem',
+
+        'alternatively' => [
+            'hash' => '$2y$eyyoooo$',
+        ],
+    ],
+];
+
+/**
+ * Test suite for Secrets.
+ *
+ * Test data is also sampled from the detect-secrets project.
+ */
+class SecretsTest extends TestCase
+{
+
+    public function testKeys()
+    {
+        $secrets = Secrets::create();
+
+        $this->assertFalse($secrets->isSecretKey('red_herring'));
+        $this->assertFalse($secrets->isSecretKey('aws_access_key'));
+        $this->assertTrue($secrets->isSecretKey('aws_secret_access_key'));
+    }
+
+
+    public function testValues()
+    {
+        $secrets = Secrets::create();
+
+        $this->assertFalse($secrets->isSecretValue(DATA['red_herring']));
+        $this->assertTrue($secrets->isSecretValue(DATA['aws_access_key']));
+        $this->assertFalse($secrets->isSecretValue(DATA['aws_secret_access_key']));
+    }
+
+
+    public function testBase64() {
+        $secrets = Secrets::create(['base64' => true]);
+        $this->assertTrue($secrets->isSecretValue(DATA['base64_secret']));
+        $this->assertTrue($secrets->isSecretValue(DATA['base64_secret']));
+
+        $secrets = Secrets::create(['base64' => false]);
+        $this->assertFalse($secrets->isSecretValue(DATA['base64_secret']));
+        $this->assertTrue($secrets->isSecretValue(DATA['base64_sub_secret']));
+    }
+
+
+    public function testHex() {
+        $secrets = Secrets::create(['hex' => true]);
+        $this->assertTrue($secrets->isSecretValue(DATA['hex_secret']));
+        $this->assertTrue($secrets->isSecretValue(DATA['hex_sub_secret']));
+
+        $secrets = Secrets::create(['hex' => false]);
+        $this->assertFalse($secrets->isSecretValue(DATA['hex_secret']));
+        $this->assertTrue($secrets->isSecretValue(DATA['hex_sub_secret']));
+    }
+
+
+    public function testMasking()
+    {
+        $input = DATA;
+
+        $secrets = Secrets::create();
+        $actual = $secrets->mask($input);
+
+        $expected = [
+            'red_herring' => 'DEADBEEF',
+            'id' => 'YW1pYWx3YXlzZ2VuZXJhdGluZ3BheWxvYWRzd2hlbmltaHVuZ3J5b3JhbWlhbHdheXNodW5ncnk',
+            'base64_secret' => '*************************',
+            'base64_sub_secret' => '*************************',
+            'hex_secret' => '*************************',
+            'hex_sub_secret' => '*************************',
+            'basic_auth' => 'http://username:whywouldyouusehttpforpasswords@example.com',
+            'aws_access_key' => '********************',
+            'aws_secret_access_key' => '*************************',
+            'stripe' => [
+                'key' => '****************',
+                'publishable' => 'pk_livenot-a-problem',
+                'alternatively' => [
+                    'hash' => '************',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+
+    public function testClean()
+    {
+        $this->markTestSkipped('recursive mode is unfinished');
+
+        $input = DATA;
+
+        $secrets = Secrets::create();
+        $actual = $secrets->clean($input);
+
+        $expected = [
+            'red_herring' => 'DEADBEEF',
+            'id' => 'YW1pYWx3YXlzZ2VuZXJhdGluZ3BheWxvYWRzd2hlbmltaHVuZ3J5b3JhbWlhbHdheXNodW5ncnk',
+            'basic_auth' => 'http://username:whywouldyouusehttpforpasswords@example.com',
+            'stripe' => [
+                'publishable' => 'pk_livenot-a-problem',
+                'alternatively' => [
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+}

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -71,7 +71,8 @@ class SecretsTest extends TestCase
     }
 
 
-    public function testBase64() {
+    public function testBase64()
+    {
         $secrets = Secrets::create(['base64' => true]);
         $this->assertTrue($secrets->isSecretValue(DATA['base64_secret']));
         $this->assertTrue($secrets->isSecretValue(DATA['base64_secret']));
@@ -82,7 +83,8 @@ class SecretsTest extends TestCase
     }
 
 
-    public function testHex() {
+    public function testHex()
+    {
         $secrets = Secrets::create(['hex' => true]);
         $this->assertTrue($secrets->isSecretValue(DATA['hex_secret']));
         $this->assertTrue($secrets->isSecretValue(DATA['hex_sub_secret']));
@@ -93,7 +95,8 @@ class SecretsTest extends TestCase
     }
 
 
-    public function testCustomRuleSet() {
+    public function testCustomRuleSet()
+    {
         $secrets = Secrets::create([
             'value_rules' => ['ITSASECRET-[0-9]+-ENDOFSECRET'],
         ]);
@@ -110,7 +113,8 @@ class SecretsTest extends TestCase
     }
 
 
-    public function testCustomRuleSingle() {
+    public function testCustomRuleSingle()
+    {
         $secrets = Secrets::create();
 
         $secrets->addValueRule('^KBPHP.+\|.+');

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -25,6 +25,8 @@ const DATA = [
     'aws_access_key' => 'AKIAIOSFODNN7EXAMPLE',
     'aws_secret_access_key' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
 
+    'jks_empty' => '',
+
     'stripe' => [
         'key' => 'sk_liveetcetcetc',
         'publishable' => 'pk_live-not-a-problem',
@@ -76,10 +78,12 @@ class SecretsTest extends TestCase
         $secrets = Secrets::create(['base64' => true]);
         $this->assertTrue($secrets->isSecretValue(DATA['base64_secret']));
         $this->assertTrue($secrets->isSecretValue(DATA['base64_secret']));
+        $this->assertFalse($secrets->isSecretValue(DATA['jks_empty']));
 
         $secrets = Secrets::create(['base64' => false]);
         $this->assertFalse($secrets->isSecretValue(DATA['base64_secret']));
         $this->assertTrue($secrets->isSecretValue(DATA['base64_sub_secret']));
+        $this->assertFalse($secrets->isSecretValue(DATA['jks_empty']));
     }
 
 
@@ -88,10 +92,12 @@ class SecretsTest extends TestCase
         $secrets = Secrets::create(['hex' => true]);
         $this->assertTrue($secrets->isSecretValue(DATA['hex_secret']));
         $this->assertTrue($secrets->isSecretValue(DATA['hex_sub_secret']));
+        $this->assertFalse($secrets->isSecretValue(DATA['jks_empty']));
 
         $secrets = Secrets::create(['hex' => false]);
         $this->assertFalse($secrets->isSecretValue(DATA['hex_secret']));
         $this->assertTrue($secrets->isSecretValue(DATA['hex_sub_secret']));
+        $this->assertFalse($secrets->isSecretValue(DATA['jks_empty']));
     }
 
 
@@ -148,6 +154,7 @@ class SecretsTest extends TestCase
             'badly_named_aws_bits' => '****************',
             'aws_access_key' => '****************',
             'aws_secret_access_key' => '****************',
+            'jks_empty' => '',
             'stripe' => [
                 'key' => '****************',
                 'publishable' => 'pk_live-not-a-problem',
@@ -181,6 +188,7 @@ class SecretsTest extends TestCase
         $expected = [
             'red_herring' => 'DEADBEEF',
             'id' => 'YW1pYWx3YXlzZ2VuZXJhdGluZ3BheWxvYWRzd2hlbmltaHVuZ3J5b3JhbWlhbHdheXNodW5ncnk',
+            'jks_empty' => '',
             'stripe' => [
                 'publishable' => 'pk_live-not-a-problem',
                 'alternatively' => [

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -93,6 +93,39 @@ class SecretsTest extends TestCase
     }
 
 
+    public function testCustomRuleSet() {
+        $secrets = Secrets::create([
+            'value_rules' => ['ITSASECRET-[0-9]+-ENDOFSECRET'],
+        ]);
+
+        // Good.
+        $this->assertTrue($secrets->isSecretValue('ITSASECRET-12345-ENDOFSECRET'));
+        $this->assertFalse($secrets->isSecretValue('ITSASECRET-abc-ENDOFSECRET'));
+
+        // Also good (technically).
+        $this->assertFalse($secrets->isSecretValue('sq0csp-abcdef'));
+
+        // But this still works.
+        $this->assertTrue($secrets->isSecretKey('password_hash'));
+    }
+
+
+    public function testCustomRuleSingle() {
+        $secrets = Secrets::create();
+
+        $secrets->addValueRule('^KBPHP.+\|.+');
+
+        // Good.
+        $this->assertTrue($secrets->isSecretValue('KBPHPabcdefg|1234567890'));
+
+        // Meh.
+        $this->assertFalse($secrets->isSecretValue('KBPHP|notquite'));
+
+        // This still works.
+        $this->assertTrue($secrets->isSecretValue('sq0csp-abcdef'));
+    }
+
+
     public function testMasking()
     {
         $input = DATA;


### PR DESCRIPTION
Secrets cleaning!

Hoping to include this into Sprout asap so the exception logs aren't so scary. Generally this gives us a bit more confidence to log various bodies of content without exposing secrets by accident.

## Usage

In it's most basic form:

```php 
$safe = Secrets::create()->mask($_POST);
```

You can also simply delete the offending keys with `->clean()`.

## Neat stuff
There's two things to identify a secret.

1. The key name,  like `secret, key, password, token, cvv`.
2. The value itself, Stripe and Github like to prefix all their stuff which is super handy, like `sk_live` or `ghp_`.

The values one is quite interesting, we can identify and clean up a lot of things. Say you've wrapped your secrets in a base64 or hex string - this will still find them.

There's a handful of helpers on there that could be used in other ways. I was hoping to include a find-replace in text bodies but that was a bit too much work.

## Tests
Tests are present and passing.

## Notes

Also added a handy recursive filter method that PHP never added to core, for some reason.
