### PR TITLE
Feat/events

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2023 Karmabunny
+ */
+
+namespace karmabunny\kb;
+
+/**
+ * An abstract base event.
+ *
+ * @package Bloom\Base
+ */
+abstract class Event extends DataObject implements EventInterface
+{
+
+    /** @var object|null */
+    public $sender;
+
+    /** @var bool */
+    public $handled = false;
+
+}

--- a/src/EventInterface.php
+++ b/src/EventInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2023 Karmabunny
+ */
+
+namespace karmabunny\kb;
+
+/**
+ * An event.
+ *
+ * @package Bloom\Base
+ */
+interface EventInterface
+{
+}

--- a/src/EventableTrait.php
+++ b/src/EventableTrait.php
@@ -62,15 +62,16 @@ trait EventableTrait
      *
      * @see Events::on()
      * @param class-string<EventInterface>|callable $event
-     * @param callable|null $fn
+     * @param callable|bool|null $fn
+     * @param bool $append
      * @return void
      * @throws InvalidArgumentException
      */
-    public function on($event, callable $fn = null)
+    public function on($event, $fn = null, bool $append = true)
     {
         // Unlike trigger, using dynamic class names here is OK. A user is not
         // surprised (hopefully) that they only receive events appropriate for
         // the leaf node that is 'this'.
-        Events::on(static::class, $event, $fn);
+        Events::on(static::class, $event, $fn, $append);
     }
 }

--- a/src/EventableTrait.php
+++ b/src/EventableTrait.php
@@ -61,7 +61,7 @@ trait EventableTrait
      * ```
      *
      * @see Events::on()
-     * @param string|callable $event
+     * @param class-string<EventInterface>|callable $event
      * @param callable|null $fn
      * @return void
      * @throws InvalidArgumentException

--- a/src/EventableTrait.php
+++ b/src/EventableTrait.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2023 Karmabunny
+ */
+
+namespace karmabunny\kb;
+
+use InvalidArgumentException;
+
+/**
+ * Implements events helpers.
+ *
+ * @package Bloom\Base
+ */
+trait EventableTrait
+{
+
+
+    /**
+     * Fire an event.
+     *
+     * When calling this method, it's best to avoid self/static/get_class and
+     * explicitly declare which class is emitting the event.
+     *
+     * Although `self` is reasonably predictable, there's plenty of potential
+     * for confusion - so please be cautious.
+     *
+     * ```
+     * // Good
+     * this->trigger(MyClass::class, $event);
+     *
+     * // Beware
+     * $this->trigger(self::class, $event);
+     * $this->trigger(static::class, $event);
+     * $this->trigger(get_class($this), $event);
+     * ```
+     *
+     * @see Events::trigger()
+     * @param EventInterface $event
+     * @return array handler results
+     */
+    protected function trigger(string $class, EventInterface &$event): array
+    {
+        if ($event instanceof Event) {
+            $event->sender = $this;
+        }
+
+        return Events::trigger($class, $event);
+    }
+
+
+    /**
+     * Listen to an event.
+     *
+     * This will receive events from the instance class, and events from any
+     * parent class.
+     *
+     * ```
+     * $this->on(function(MyEvent $event) {});
+     * ```
+     *
+     * @see Events::on()
+     * @param string|callable $event
+     * @param callable|null $fn
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public function on($event, callable $fn = null)
+    {
+        // Unlike trigger, using dynamic class names here is OK. A user is not
+        // surprised (hopefully) that they only receive events appropriate for
+        // the leaf node that is 'this'.
+        Events::on(static::class, $event, $fn);
+    }
+}

--- a/src/Events.php
+++ b/src/Events.php
@@ -60,7 +60,7 @@ class Events
      * - `self::class`
      * - `get_class($this)`
      *
-     * @param string $sender
+     * @param class-string $sender
      * @param EventInterface $event
      * @return array[] event results.
      */
@@ -116,8 +116,8 @@ class Events
      * In the second form the event type is derived from the first parameter
      * of the handler function.
      *
-     * @param string $sender
-     * @param string|callable $event
+     * @param class-string $sender
+     * @param class-string<EventInterface>|callable $event
      * @param callable|null $fn
      * @return void
      * @throws InvalidArgumentException
@@ -153,7 +153,6 @@ class Events
             throw new InvalidArgumentException("Event '{$event}' is not an EventInterface");
         }
 
-
         self::$_events[$sender][$event][] = $fn;
     }
 
@@ -161,8 +160,10 @@ class Events
     /**
      * Remove listeners.
      *
-     * @param string $sender
-     * @param string|null $event
+     * If `$event` is not given, all events are removed from the sender.
+     *
+     * @param class-string $sender
+     * @param class-string<EventInterface>|null $event
      * @return void
      */
     public static function off(string $sender, string $event = null)
@@ -230,6 +231,13 @@ class Events
     }
 
 
+    /**
+     * Has this event been triggered?
+     *
+     * @param class-string $sender
+     * @param class-string<EventInterface> $event
+     * @return bool
+     */
     public static function hasRun(string $sender, string $event): bool
     {
         if ($sender === '*') {

--- a/src/Events.php
+++ b/src/Events.php
@@ -160,15 +160,19 @@ class Events
     /**
      * Remove listeners.
      *
-     * If `$event` is not given, all events are removed from the sender.
+     * If `$event` is not given (null), all listeners are removed from the sender.
      *
-     * @param class-string $sender
+     * Specify a `null` sender to remove all listeners from an event.
+     *
+     * Or both `null, null` to remove _all_ listeners from all senders.
+     *
+     * @param class-string|null $sender
      * @param class-string<EventInterface>|null $event
      * @return void
      */
-    public static function off(string $sender, string $event = null)
+    public static function off(?string $sender, string $event = null)
     {
-        if ($sender === '*') {
+        if ($sender === null) {
             if ($event) {
                 foreach (array_keys(self::$_events) as $sender) {
                     unset(self::$_events[$sender][$event]);

--- a/src/Events.php
+++ b/src/Events.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2023 Karmabunny
+ */
+
+namespace karmabunny\kb;
+
+use InvalidArgumentException;
+use ReflectionException;
+use ReflectionFunction;
+use ReflectionNamedType;
+
+/**
+ * A static events system.
+ *
+ * @package Bloom\Base
+ */
+class Events
+{
+
+    /**
+     * [emitter][event] = [ listener, listener... ]
+     *
+     * @var callable[][][]
+     */
+    protected static $_events = [];
+
+
+    /**
+     * Fire an event.
+     *
+     * Given a class tree like:
+     *
+     * ```
+     *        Root
+     *       /   \
+     *     Sub   Other
+     *     /
+     *   Leaf
+     * ```
+     *
+     * Events will propagate from their respective class subtree. Such as,
+     * 'Sub' will emit on both 'Sub' and 'Leaf', even though the class inherits
+     * from 'Root'. Whereas events from 'Root' will emit on every class.
+     *
+     * Triggering events in a class that is not it's own, or even from
+     * a parent class is _strongly_ discouraged.
+     *
+     * _Don't_ use dynamic class names, such as:
+     * - `static::class`
+     * - `self::class`
+     * - `get_class($this)`
+     *
+     * @param string $sender
+     * @param EventInterface $event
+     * @return array[] event results.
+     */
+    public static function trigger(string $sender, EventInterface &$event): array
+    {
+        // Events are ID'd by their full namespaced class name.
+
+        $handlers = [];
+
+        foreach (self::$_events as $class => $events) {
+            // Permit subclass emitters to trigger root handlers.
+            // But not the other way - roots cannot trigger subclass handlers.
+            if (!is_a($class, $sender, true)) continue;
+
+            $some = $events[get_class($event)] ?? [];
+
+            // Add handlers in reverse.
+            // This retains the order of classes (registration order) but each
+            // set of handlers are executed in reverse (LIFO).
+            // This is desirable so that handlers registered later are able to
+            // override or prevent behaviour of earlier handlers.
+            foreach ($some as $handler) {
+                array_unshift($handlers, $handler);
+            }
+        }
+
+        $results = [];
+
+        // Fire off.
+        foreach ($handlers as $fn) {
+            $results[] = $fn($event);
+        }
+
+        return $results;
+    }
+
+
+    /**
+     * Listen to an event.
+     *
+     * This method has two signatures:
+     *
+     * ```
+     * // Full form
+     * Events::on(Emitter::class, Event::class, function(MyEvent $event) {});
+     *
+     * // Short form
+     * Events::on(Emitter::class, function(MyEvent $event) {});
+     * ```
+     *
+     * In the second form the event type is derived from the first parameter
+     * of the handler function.
+     *
+     * @param string $sender
+     * @param string|callable $event
+     * @param callable|null $fn
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public static function on(string $sender, $event, callable $fn = null)
+    {
+        // If no handler is given, assume the second parameter is handler.
+        // Using some cheeky reflection we can extract the event type.
+        if (!$fn) {
+            try {
+                $fn = $event;
+                $event = null;
+
+                $reflect = new ReflectionFunction($fn);
+
+                if (
+                    ($parameters = $reflect->getParameters())
+                    and ($type = $parameters[0]->getType())
+                    and ($type instanceof ReflectionNamedType)
+                ) {
+                    $event = $type->getName();
+                }
+            }
+            catch (ReflectionException $exception) {
+                throw new InvalidArgumentException("Invalid event handler", 0, $exception);
+            }
+        }
+
+        if (!is_subclass_of($event, EventInterface::class)) {
+            throw new InvalidArgumentException("Not an Event subclass: {$event}");
+        }
+
+
+        self::$_events[$sender][$event][] = $fn;
+    }
+
+
+    /**
+     * Remove listeners.
+     *
+     * @param string $sender
+     * @param string|null $event
+     * @return void
+     */
+    public static function off(string $sender, string $event = null)
+    {
+        if ($event) {
+            unset(self::$_events[$sender][$event]);
+        }
+        else {
+            unset(self::$_events[$sender]);
+        }
+    }
+}

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -1,0 +1,380 @@
+<?php
+
+use karmabunny\kb\Event;
+use karmabunny\kb\Events;
+use karmabunny\kb\EventableTrait;
+use PHPUnit\Framework\TestCase;
+
+
+class EventTest extends TestCase
+{
+
+    public function setUp(): void
+    {
+        EventsReset::reset();
+    }
+
+
+    /**
+     * Root listeners receive root events.
+     */
+    public function testBasic()
+    {
+        $count = 0;
+
+        // Instance long form.
+        $emitter = new RootEmitter();
+        $emitter->on(TestEvent::class, function() use (&$count) {
+            $count++;
+            return 'one';
+        });
+
+        $actual = $emitter->testRoot();
+
+        $this->assertEquals(1, $count);
+        $this->assertCount(1, $actual);
+        $this->assertEquals(['one'], $actual);
+
+        // Instance short form.
+        $emitter->on(function(TestEvent $event) use (&$count) {
+            $count++;
+            return 'two';
+        });
+
+        $count = 0;
+        $actual = $emitter->testRoot();
+
+        $this->assertEquals(2, $count);
+        $this->assertCount(2, $actual);
+        $this->assertEquals(['two', 'one'], $actual);
+
+        // Static long form.
+        Events::on(RootEmitter::class, TestEvent::class, function() use (&$count) {
+            $count++;
+            return 'three';
+        });
+
+        $count = 0;
+        $actual = $emitter->testRoot();
+
+        $this->assertEquals(3, $count);
+        $this->assertCount(3, $actual);
+        $this->assertEquals(['three', 'two', 'one'], $actual);
+
+        // Static short form.
+        Events::on(RootEmitter::class, function(TestEvent $event) use (&$count) {
+            $count++;
+            return 'four';
+        });
+
+        $count = 0;
+        $actual = $emitter->testRoot();
+
+        $this->assertEquals(4, $count);
+        $this->assertCount(4, $actual);
+        $this->assertEquals(['four', 'three', 'two', 'one'], $actual);
+    }
+
+
+    /**
+     * Sub class listeners receive subclass events.
+     */
+    public function testSubclass()
+    {
+        $count = 0;
+
+        Events::on(SubEmitter::class, TestEvent::class, function() use (&$count) {
+            $count++;
+            return true;
+        });
+
+        $emitter = new SubEmitter();
+
+        // from ROOT to SUB works.
+        $actual = $emitter->testRoot();
+        $this->assertEquals(1, $count);
+        $this->assertCount(1, $actual);
+
+        // from SELF (root) to SUB works.
+        $actual = $emitter->testSelf();
+        $this->assertEquals(2, $count);
+        $this->assertCount(1, $actual);
+
+        // from THIS (sub) to SUB works.
+        $actual = $emitter->testDynamic();
+        $this->assertEquals(3, $count);
+        $this->assertCount(1, $actual);
+    }
+
+
+    /**
+     * Sub class listeners receive root events.
+     *
+     * This test is identical to the previous. The emitter type is only
+     * relevant to 'dynamic' events - which are discouraged.
+     */
+    public function testSubclassIndirect()
+    {
+        $count = 0;
+
+        Events::on(SubEmitter::class, TestEvent::class, function() use (&$count) {
+            $count++;
+            return true;
+        });
+
+        $emitter = new RootEmitter();
+
+        // from ROOT to SUB works.
+        $actual = $emitter->testRoot();
+        $this->assertEquals(1, $count);
+        $this->assertCount(1, $actual);
+
+        // from SELF (root) to SUB works.
+        $actual = $emitter->testSelf();
+        $this->assertEquals(2, $count);
+        $this->assertCount(1, $actual);
+
+        // from THIS (root) to SUB works.
+        $actual = $emitter->testDynamic();
+        $this->assertEquals(3, $count);
+        $this->assertCount(1, $actual);
+    }
+
+
+    /**
+     * Root listeners _do not_ receive subclass events.
+     */
+    public function testSubclassInverse()
+    {
+        $count = 0;
+
+        Events::on(RootEmitter::class, TestEvent::class, function() use (&$count) {
+            $count++;
+            return true;
+        });
+
+        $emitter = new SubEmitter();
+
+        // from SUB to ROOT fails.
+        $actual = $emitter->testSub();
+        $this->assertEquals(0, $count);
+        $this->assertCount(0, $actual);
+
+        // from THIS (sub) to ROOT fails.
+        $actual = $emitter->testDynamic();
+        $this->assertEquals(0, $count);
+        $this->assertCount(0, $actual);
+
+        // from ROOT to ROOT works.
+        $actual = $emitter->testRoot();
+        $this->assertEquals(1, $count);
+        $this->assertCount(1, $actual);
+
+        // from SELF (root) to ROOT fails;
+        $actual = $emitter->testSelf();
+        $this->assertEquals(2, $count);
+        $this->assertCount(1, $actual);
+    }
+
+
+    /**
+     * Sub listeners _do not_ receive events from siblings.
+     */
+    public function testSiblings()
+    {
+        $count = 0;
+
+        Events::on(OtherEmitter::class, TestEvent::class, function() use (&$count) {
+            $count++;
+            return true;
+        });
+
+        $emitter = new SubEmitter();
+
+        // from SUB to OTHER fails.
+        $actual = $emitter->testSub();
+        $this->assertEquals(0, $count);
+        $this->assertCount(0, $actual);
+
+        // from THIS (sub) to OTHER fails.
+        $actual = $emitter->testDynamic();
+        $this->assertEquals(0, $count);
+        $this->assertCount(0, $actual);
+
+        // from ROOT to OTHER works.
+        $actual = $emitter->testRoot();
+        $this->assertEquals(1, $count);
+        $this->assertCount(1, $actual);
+
+        // from SELF (root) to OTHER works.
+        $actual = $emitter->testSelf();
+        $this->assertEquals(2, $count);
+        $this->assertCount(1, $actual);
+    }
+
+
+    /**
+     * Leaf nodes receive all events, siblings and roots do not.
+     */
+    public function testNested()
+    {
+        $count = 0;
+
+        Events::on(RootEmitter::class, TestEvent::class, function() use (&$count) {
+            $count++;
+            return 'root';
+        });
+
+        Events::on(SubEmitter::class, TestEvent::class, function() use (&$count) {
+            $count++;
+            return 'sub';
+        });
+
+        Events::on(LeafEmitter::class, TestEvent::class, function() use (&$count) {
+            $count++;
+            return 'leaf1';
+        });
+
+        Events::on(LeafEmitter::class, TestEvent::class, function() use (&$count) {
+            $count++;
+            return 'leaf2';
+        });
+
+        Events::on(OtherEmitter::class, TestEvent::class, function() use (&$count) {
+            $count++;
+            return 'other';
+        });
+
+        $emitter = new LeafEmitter();
+
+        // All classes receive an event from 'root'.
+        // from ROOT to ALL
+        $actual = $emitter->testRoot();
+        $this->assertEquals(5, $count);
+        $this->assertCount(5, $actual);
+        $this->assertEquals(['other', 'leaf2', 'leaf1', 'sub', 'root'], $actual);
+
+        // Partial tree of events.
+        // from SUB to SUB + LEAF
+        $count = 0;
+        $actual = $emitter->testSub();
+        $this->assertEquals(3, $count);
+        $this->assertCount(3, $actual);
+        $this->assertEquals(['leaf2', 'leaf1', 'sub'], $actual);
+
+        // from LEAF to LEAF
+        $count = 0;
+        $actual = $emitter->testLeaf();
+        $this->assertEquals(2, $count);
+        $this->assertCount(2, $actual);
+        $this->assertEquals(['leaf2', 'leaf1'], $actual);
+
+        // from SELF (root) to LEAF
+        $count = 0;
+        $actual = $emitter->testSelf();
+        $this->assertEquals(5, $count);
+        $this->assertCount(5, $actual);
+        $this->assertEquals(['other', 'leaf2', 'leaf1', 'sub', 'root'], $actual);
+
+        // from THIS (leaf) to LEAF
+        $count = 0;
+        $actual = $emitter->testDynamic();
+        $this->assertEquals(2, $count);
+        $this->assertCount(2, $actual);
+        $this->assertEquals(['leaf2', 'leaf1'], $actual);
+
+        $emitter = new SubEmitter();
+
+        // Dynamic events from SubEmitter will trigger for both sub and leaf.
+        // from THIS (sub) to LEAF
+        $count = 0;
+        $actual = $emitter->testDynamic();
+        $this->assertEquals(3, $count);
+        $this->assertCount(3, $actual);
+        $this->assertEquals(['leaf2', 'leaf1', 'sub'], $actual);
+    }
+}
+
+
+class TestEvent extends Event {}
+
+
+class EventsReset extends Events
+{
+    public static function reset()
+    {
+        Events::$_events = [];
+    }
+}
+
+
+/**
+ * The class hierarchy looks like this:
+ *
+ *        Root
+ *       /   \
+ *     Sub   Other
+ *     /
+ *   Leaf
+ *
+ * - Children can receive all parent events.
+ * - Parents cannot receive child events.
+ */
+class RootEmitter
+{
+    use EventableTrait;
+
+    public function testRoot(): array
+    {
+        $event = new TestEvent();
+        $results = $this->trigger(RootEmitter::class, $event);
+        return $results;
+    }
+
+    public function testSelf(): array
+    {
+        $event = new TestEvent();
+        $results = $this->trigger(self::class, $event);
+        return $results;
+    }
+
+    public function testDynamic(): array
+    {
+        $event = new TestEvent();
+        $results = $this->trigger(get_class($this), $event);
+        return $results;
+    }
+}
+
+
+class SubEmitter extends RootEmitter
+{
+    public function testSub(): array
+    {
+        $event = new TestEvent();
+        $results = $this->trigger(SubEmitter::class, $event);
+        return $results;
+    }
+}
+
+
+class LeafEmitter extends SubEmitter
+{
+    public function testLeaf(): array
+    {
+        $event = new TestEvent();
+        $results = $this->trigger(LeafEmitter::class, $event);
+        return $results;
+    }
+}
+
+
+class OtherEmitter extends RootEmitter
+{
+    public function testSub(): array
+    {
+        $event = new TestEvent();
+        $results = $this->trigger(OtherEmitter::class, $event);
+        return $results;
+    }
+}


### PR DESCRIPTION
An events system!

It's an interesting implementation; in particular there are no 'generic' events. Each event class type identifies itself - the idea being that you can't accidentally emit `'beforeAction'` with the `ShutdownEvent` class. There's also no confusion about what events ids belong with which classes.

The downside is a proliferation of 100x more event classes - one for each event type. That said, you can reuse events across different emitters - so this effect is reduced.

Before anyone says it - no, this doesn't have the scope for an inter-system async event bus. You can reuse the EventInterface to integrate an implementation in another library if you like but anything else is beyond.

I'm happy with it.