### PR TITLE
Validation exception labels

### DIFF
--- a/src/RulesValidator.php
+++ b/src/RulesValidator.php
@@ -577,11 +577,14 @@ class RulesValidator implements Validator
         foreach ($this->general_errors as $msgs) {
             $errors[''][] = $msgs;
         }
+
         foreach ($this->field_errors as $field => $msgs) {
-            $errors[$this->labels[$field]] = $msgs;
+            $key = $this->labels[$field] ?? $field;
+            $errors[$key] = $msgs;
         }
 
         $out = [];
+
         foreach ($errors as $label => $msgs) {
             $out[$label] = implode('. ', $msgs);
         }


### PR DESCRIPTION
So adding labels here isn't difficult, but the workflow might just be a bit clunky.

For models example I imagine:

```php
$labels = [ 'name' => 'Human name' ];

try {
  $model->validate();
} catch (ValidationException $exception) {
  $exception->setLabels($labels);
  throw $exception;
}
```

It's all a bit blah.


### Validator

For integrating with the standard validation class (a la Sprout) it would look like this. Much tidier.

```php
$valid = new RulesValidator($_POST);
$valid->required(['name', 'email']);

$labels = [
  'name' => 'Full name',
  'email' => 'Email Address',
];

$errors = $valid->getErrors();

if (!empty($errors)) {
  throw (new ValidationException)
     ->addErrors($errors)
     ->setLabels($labels);
}
```

The rules validator could actually house this code and expose a `validate()` helper method I reckon.


### More ideas

A half-baked idea: we could extend our concept of scenarios to accept alternate validator instances. Because really a 'scenario' is just an alternate set of validation checks.

```php
$valid = new RulesValidator($_POST);
$valid->check('email', 'Validity::email');
$valid->setLabels(['email' => 'Email Address']);

// Pass in this validator instance, the exception carries fields + labels all the way through
$model->validate($valid);

// OR
$model = MyModel::findOne(['id' => $id]);
$model->update($_POST);

// Pulls rules from a specific scenario in the MyModel::rules()
$valid = new RulesValidator($model, 'scenario-name');

// Alternate, more agricultural.
$valid->fromScenario($model, 'scenario-name');

// Add labels, additional rules, etc.
$valid->setLabels(['email' => 'Email Address']);

// Same deal, happy labels + etc.
$model->validate($valid);
```
