### PR TITLE
Feat/arrayable filters

### DIFF
--- a/src/ArrayableTrait.php
+++ b/src/ArrayableTrait.php
@@ -126,7 +126,9 @@ trait ArrayableTrait
 
         // Add extra fields.
         if ($extra) {
-            $extra_keys = array_fill_keys($extra, true);
+            $extra_keys = Arrays::keyRoots($extra, true);
+            $extra_keys = array_fill_keys($extra_keys, true);
+
             $extra_fields = [];
 
             // Extract any virtual fields.
@@ -142,13 +144,14 @@ trait ArrayableTrait
 
         // Apply filters.
         if ($filter) {
-            $filter = array_fill_keys($filter, true);
+            $filter_keys = Arrays::keyRoots($filter);
+            $filter_keys = array_fill_keys($filter_keys, true);
 
             // Extract any virtual fields.
-            $fields = array_intersect_key($fields, $filter);
+            $fields = array_intersect_key($fields, $filter_keys);
 
             // Re-apply any in 'filter' not already in fields().
-            $fields = array_merge($filter, $fields);
+            $fields = array_merge($filter_keys, $fields);
         }
 
         $array = [];
@@ -199,7 +202,14 @@ trait ArrayableTrait
                 or $item instanceof Arrayable
                 or $item instanceof Traversable
             ) {
-                $item = Arrays::toArray($item);
+                $next_filter = $filter ? Arrays::keyChildren($key, $filter) : null;
+                $next_extra = $extra ? Arrays::keyChildren($key, $extra, true) : null;
+
+                $item = Arrays::toArray($item, $next_filter, $next_extra);
+
+                if (empty($item)) {
+                    continue;
+                }
             }
 
             $array[$key] = $item;

--- a/src/ArrayableTrait.php
+++ b/src/ArrayableTrait.php
@@ -107,7 +107,6 @@ trait ArrayableTrait
      * Specify an 'extra' to include additional fields if implementing the
      * ArrayableFields interface. This will add properties that were excluded
      * from `fields()` and includes any virtual fields defined in `extraFields()`.
-     * included in `fields()` and any virtual fields defined in `extraFields()`.
      *
      * @param string[]|null $filter
      * @param string[]|null $extra
@@ -124,24 +123,6 @@ trait ArrayableTrait
             $fields = array_merge($fields, $this->fields());
         }
 
-        // Add extra fields.
-        if ($extra) {
-            $extra_keys = Arrays::keyRoots($extra, true);
-            $extra_keys = array_fill_keys($extra_keys, true);
-
-            $extra_fields = [];
-
-            // Extract any virtual fields.
-            if ($this instanceof ArrayableFields) {
-                $extra_fields = $this->extraFields();
-                $extra_fields = array_intersect_key($extra_fields, $extra_keys);
-            }
-
-            // The 'extras' field can also reference natural fields or those
-            // in fields(), so we layer them all together.
-            $fields = array_merge($fields, $extra_keys, $extra_fields);
-        }
-
         // Apply filters.
         if ($filter) {
             $filter_keys = Arrays::keyRoots($filter);
@@ -152,6 +133,21 @@ trait ArrayableTrait
 
             // Re-apply any in 'filter' not already in fields().
             $fields = array_merge($filter_keys, $fields);
+        }
+
+        // Add extra fields.
+        if ($extra) {
+            $extra_keys = Arrays::keyRoots($extra, true);
+            $extra_keys = array_fill_keys($extra_keys, true);
+
+            $fields = array_merge($fields, $extra_keys);
+
+            if ($this instanceof ArrayableFields) {
+                $extra_fields = $this->extraFields();
+                $extra_fields = array_intersect_key($extra_fields, $extra_keys);
+
+                $fields = array_merge($fields, $extra_fields);
+            }
         }
 
         $array = [];

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -1030,6 +1030,67 @@ class Arrays
 
 
     /**
+     * Get root keys from a list of array queries.
+     *
+     * ```
+     * $keys = ['root1.child', 'root2.child.deep'];
+     * $roots = Arrays::keyRoots($keys);
+     * // => [ 'root1', 'root2' ]
+     * ```
+     *
+     * @param string[] $keys
+     * @return string[]
+     */
+    public static function keyRoots(array $keys): array
+    {
+        $roots = [];
+
+        foreach ($keys as $key) {
+            $parts = explode('.', $key, 2);
+            $part = array_shift($parts);
+            $roots[$part] = $part;
+        }
+
+        $roots = array_keys($roots);
+        return $roots;
+    }
+
+
+    /**
+     * Get child keys from a list of array queries.
+     *
+     * ```
+     * $keys = ['root1.child', 'root2.child.deep'];
+     * $children = Arrays::keyChildren($keys);
+     * // => [ 'child', 'child.deep' ]
+     * ```
+     *
+     * @param string $root
+     * @param array $keys
+     * @return array
+     */
+    public static function keyChildren(string $root, array $keys): array
+    {
+        $children = [];
+
+        foreach ($keys as $key) {
+            $parts = explode('.', $key, 2);
+            $part = array_shift($parts);
+
+            if (empty($parts)) {
+                continue;
+            }
+
+            if ($part === $root) {
+                $children[] = $parts[0];
+            }
+        }
+
+        return $children;
+    }
+
+
+    /**
      * Shorthand for putting together [key => value] maps.
      *
      * This will silently skip over invalid items:

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -969,6 +969,67 @@ class Arrays
 
 
     /**
+     * Shift all the root elements from a list of array queries.
+     *
+     * ```
+     * $keys = [
+     *    'one.two.three',
+     *    'def.ghi',
+     *    '**.deep',
+     * ];
+     *
+     * $shift = Arrays::shiftKeys($keys);
+     * // $shift == [ 'one', 'def', 'deep' ]
+     * // $keys == [ 'two.three', 'ghi', '**.deep' ]
+     *
+     * $shift = Arrays::shiftKeys($keys);
+     * // $shift == [ 'two', 'ghi', 'deep' ]
+     * // $keys == [ 'three', '**.deep' ]
+     *
+     * $shift = Arrays::shiftKeys($keys);
+     * // $shift == [ 'three', 'deep' ]
+     * // $keys == [ '**.deep' ]
+     * ```
+     *
+     * @param string[] $keys modified by ref, leaving only children
+     * @return string[] the key roots
+     */
+    public static function shiftKeys(array &$keys): array
+    {
+        $first = [];
+        $numeric = true;
+        $i = 0;
+
+        foreach ($keys as $index => &$key) {
+            if ($index !== $i++) {
+                $numeric = false;
+            }
+
+            $parts = explode('.', $key, 2);
+            $part = array_shift($parts);
+
+            if (empty($parts)) {
+                $first[$index] = $part;
+                unset($keys[$index]);
+            }
+            else {
+                $first[$index] = $part;
+                $key = $parts[0];
+            }
+        }
+
+        unset($key);
+
+        if ($numeric) {
+            $keys = array_values($keys);
+            $first = array_values($first);
+        }
+
+        return $first;
+    }
+
+
+    /**
      * Shorthand for putting together [key => value] maps.
      *
      * This will silently skip over invalid items:

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -1196,19 +1196,34 @@ class Arrays
         $children = [];
 
         foreach ($keys as $key) {
-            $parts = explode('.', $key, 2);
+            $parts = explode('.', $key, 3);
             $part = array_shift($parts);
 
             if (empty($parts)) {
                 continue;
             }
 
-            if (
-                $part === $root
-                or ($wildcard and $part === '*')
-            ) {
-                $child = $parts[0];
+            if ($part === $root) {
+                $child = implode('.', $parts);
                 $children[$child] = $child;
+                continue;
+            }
+
+            if ($wildcard and $part === '*') {
+                $child = implode('.', $parts);
+                $children[$child] = $child;
+
+                // If the first child is the root then flatten it.
+                // wild + *.wild.card => card
+                if ($parts[0] === $root) {
+                    $child = $parts[1] ?? false;
+                    $children[$child] = $child;
+                }
+
+                // The wildcard lives forever so it can recurse.
+                $children[$key] = $key;
+
+                continue;
             }
         }
 

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -847,6 +847,10 @@ class Arrays
 
                 $item = $item->toArray($next_filter, $next_extra);
 
+                if (empty($item)) {
+                    continue;
+                }
+
                 // This performs it's own filtering so we can skip the rest.
                 $items[$key] = $item;
                 continue;
@@ -857,7 +861,17 @@ class Arrays
             }
 
             if ($item instanceof Traversable) {
-                $item = iterator_to_array($item);
+                $next_filter = self::keyChildren($key, $filter ?? []);
+                $next_extra = self::keyChildren($key, $extra ?? [], true);
+
+                $item = self::toArray($item, $next_filter, $next_extra);
+
+                if (empty($item)) {
+                    continue;
+                }
+
+                $items[$key] = $item;
+                continue;
             }
 
             if (is_object($item)) {

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -1071,14 +1071,28 @@ final class ArraysTest extends TestCase {
             'root2.child.deep',
             'root2.duplicate',
             'root3.really.really.deep',
+            '*.wild',
         ];
 
+        // Standard extract - also does dedupe.
         $actual = Arrays::keyRoots($keys);
 
         $expected = [
             'root1',
             'root2',
             'root3',
+        ];
+
+        $this->assertEquals($expected, $actual);
+
+        // Wildcards.
+        $actual = Arrays::keyRoots($keys, true);
+
+        $expected = [
+            'root1',
+            'root2',
+            'root3',
+            'wild',
         ];
 
         $this->assertEquals($expected, $actual);
@@ -1091,23 +1105,42 @@ final class ArraysTest extends TestCase {
             'root1.child',
             'root2.child.deep',
             'root2.duplicate',
+            'root2.duplicate',
             'root3.really.really.really.deep',
+            '*.wild.child',
         ];
 
+        // Standard.
         $actual = Arrays::keyChildren('root1', $keys);
         $expected = [ 'child' ];
 
         $this->assertEquals($expected, $actual);
 
+        // Testing dedupe.
         $actual = Arrays::keyChildren('root2', $keys);
         $expected = [ 'child.deep', 'duplicate' ];
 
         $this->assertEquals($expected, $actual);
 
+        // Not sure what this tests.
         $actual = Arrays::keyChildren('root3', $keys);
         $expected = [ 'really.really.really.deep' ];
 
         $this->assertEquals($expected, $actual);
+
+        // Wildcards!
+        $actual = Arrays::keyChildren('root1', $keys, true);
+        $expected = [
+            'child',
+            'wild.child',
+        ];
+
+        $this->assertEquals($expected, $actual);
+
+        // Edge-case - everything (not wildcard).
+        $actual = Arrays::keyChildren('*', $keys);
+
+        $this->assertEquals($keys, $actual);
     }
 
 

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -1064,6 +1064,53 @@ final class ArraysTest extends TestCase {
     }
 
 
+    public function testKeyRoots()
+    {
+        $keys = [
+            'root1.child',
+            'root2.child.deep',
+            'root2.duplicate',
+            'root3.really.really.deep',
+        ];
+
+        $actual = Arrays::keyRoots($keys);
+
+        $expected = [
+            'root1',
+            'root2',
+            'root3',
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+
+    public function testKeyChildren()
+    {
+        $keys = [
+            'root1.child',
+            'root2.child.deep',
+            'root2.duplicate',
+            'root3.really.really.really.deep',
+        ];
+
+        $actual = Arrays::keyChildren('root1', $keys);
+        $expected = [ 'child' ];
+
+        $this->assertEquals($expected, $actual);
+
+        $actual = Arrays::keyChildren('root2', $keys);
+        $expected = [ 'child.deep', 'duplicate' ];
+
+        $this->assertEquals($expected, $actual);
+
+        $actual = Arrays::keyChildren('root3', $keys);
+        $expected = [ 'really.really.really.deep' ];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+
     public function testCreateMap()
     {
         $objects = [

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -999,6 +999,71 @@ final class ArraysTest extends TestCase {
     }
 
 
+    public function testShiftKeys()
+    {
+        $keys = [
+            'one.two.three',
+            'def.ghi',
+        ];
+
+        // Round 1.
+        $shift = Arrays::shiftKeys($keys);
+
+        $expected = [ 'one', 'def' ];
+        $this->assertEquals($expected, $shift);
+
+        $expected = [ 'two.three', 'ghi' ];
+        $this->assertEquals($expected, $keys);
+
+        // Round 2.
+        $shift = Arrays::shiftKeys($keys);
+
+        $expected = [ 'two', 'ghi' ];
+        $this->assertEquals($expected, $shift);
+
+        $expected = [ 'three' ];
+        $this->assertEquals($expected, $keys);
+
+        // Round 3.
+        $shift = Arrays::shiftKeys($keys);
+
+        $expected = [ 'three' ];
+        $this->assertEquals($expected, $shift);
+
+        $this->assertEmpty($keys);
+
+        // Round 4.
+        $shift = Arrays::shiftKeys($keys);
+
+        $this->assertEmpty($shift);
+        $this->assertEmpty($keys);
+    }
+
+
+    public function testShiftKeysAssociated()
+    {
+        $keys = [
+            'test1' => 'one.two.three',
+            'test2' => 'def.ghi',
+        ];
+
+        // Round 1.
+        $shift = Arrays::shiftKeys($keys);
+
+        $expected = [
+            'test1' => 'one',
+            'test2' => 'def',
+        ];
+        $this->assertEquals($expected, $shift);
+
+        $expected = [
+            'test1' => 'two.three',
+            'test2' => 'ghi',
+        ];
+        $this->assertEquals($expected, $keys);
+    }
+
+
     public function testCreateMap()
     {
         $objects = [

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -1260,7 +1260,7 @@ final class ArraysTest extends TestCase {
             'root2.duplicate',
             'root2.duplicate',
             'root3.really.really.really.deep',
-            '*.wild.child',
+            '*.wild.card.deep',
         ];
 
         // Standard.
@@ -1285,7 +1285,27 @@ final class ArraysTest extends TestCase {
         $actual = Arrays::keyChildren('root1', $keys, true);
         $expected = [
             'child',
-            'wild.child',
+            'wild.card.deep',
+            '*.wild.card.deep',
+        ];
+
+        $this->assertEquals($expected, $actual);
+
+        // Deeper wildcards.
+        $actual = Arrays::keyChildren('wild', $actual, true);
+        $expected = [
+            'card.deep',
+            'wild.card.deep',
+            '*.wild.card.deep',
+        ];
+
+        // Deeper again.
+        $this->assertEquals($expected, $actual);
+        $actual = Arrays::keyChildren('card', $actual, true);
+        $expected = [
+            'deep',
+            'wild.card.deep',
+            '*.wild.card.deep',
         ];
 
         $this->assertEquals($expected, $actual);

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -775,6 +775,159 @@ final class ArraysTest extends TestCase {
     }
 
 
+    public function testToArray()
+    {
+        $array = [
+            [
+                'child1' => 123,
+                'child2' => 456,
+                'nest1' => [
+                    'child2' => 777,
+                    'child3' => 888,
+                    'list' => [1, 2, 3],
+                    'nest2' => [
+                        'child4' => 999,
+                        'child5' => '!!!',
+                    ],
+                    'nest3' => [
+                        [
+                            'child6' => 'abc',
+                            'child7' => 'def',
+                        ]
+                    ]
+                ],
+            ],
+            [
+                'child1' => 'xxx',
+                'nest1' => [
+                    'child2' => 'yyy',
+                    'nest2' => [
+                        'child3' => 'zzz',
+                    ],
+                ],
+            ],
+        ];
+
+        // A keyed array.
+        $actual = Arrays::toArray($array[0], [
+            'child1',
+            'nest1.child2',
+            'nest1.nest2.child3',
+            'nest1.nest2.child4',
+        ]);
+
+        $expected = [
+            'child1' => 123,
+            'nest1' => [
+                'child2' => 777,
+                'nest2' => [ 'child4' => 999 ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $actual);
+
+        // The other one, same query.
+        $actual = Arrays::toArray($array[1], [
+            'child1',
+            'nest1.child2',
+            'nest1.nest2.child3',
+            'nest1.nest2.child4',
+        ]);
+
+        $expected = [
+            'child1' => 'xxx',
+            'nest1' => [
+                'child2' => 'yyy',
+                'nest2' => [ 'child3' => 'zzz' ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $actual);
+
+        // Basic filter on a list.
+        $actual = Arrays::toArray($array, [ 'child1', 'child2' ]);
+        $expected = [
+            [
+                'child1' => 123,
+                'child2' => 456,
+            ],
+            [
+                'child1' => 'xxx',
+            ],
+        ];
+
+        $this->assertEquals($expected, $actual);
+
+        // Whole objects.
+        $actual = Arrays::toArray($array, [ 'nest1.nest2' ]);
+
+        $expected = [
+            [
+                'nest1' => [
+                    'nest2' => [
+                        'child4' => 999,
+                        'child5' => '!!!',
+                    ],
+                ],
+            ],
+            [
+                'nest1' => [
+                    'nest2' => [
+                        'child3' => 'zzz',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $actual);
+
+        // Some lists.
+        $actual = Arrays::toArray($array, [
+            'nest1.list',
+            'nest1.nest3.child6',
+        ]);
+
+        $expected = [
+            [
+                'nest1' => [
+                    'list' => [ 1, 2, 3 ],
+                    'nest3' => [
+                        [
+                            'child6' => 'abc',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $actual);
+
+        // Bunch of things.
+        $actual = Arrays::toArray($array, [
+            'nest1.child2',
+            'nest1.nest2.child3',
+            'nest1.nest2.child4',
+        ]);
+
+        $expected = [
+            [
+                'nest1' => [
+                    'child2' => 777,
+                    'nest2' => [ 'child4' => 999 ],
+                ],
+            ],
+            [
+                'nest1' => [
+                    'child2' => 'yyy',
+                    'nest2' => [ 'child3' => 'zzz' ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+
     public function testIsNumeric()
     {
         $this->assertTrue(Arrays::isNumeric([

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -222,13 +222,31 @@ final class CollectionTest extends TestCase {
             ],
         ];
         $this->assertEquals($expected, $array);
+    }
 
-        // filtering on extras.
+
+    public function testExtraFields() {
+        $thingo = new ThingoFields([
+            'parent_id' => 111,
+            'description' => 'blah blah blah',
+            'empty' => [
+                'lies' => 'and more lies',
+                'description' => 'test',
+            ],
+            'nested' => new ThingoFields([
+                'parent_id' => 222,
+                'description' => 'etc',
+                'empty' => [
+                    'lies' => 'not these ones',
+                    'description' => 'eyy',
+                ],
+            ])
+        ]);
+
+        // extras don't need to be in fields.
         $array = $thingo->toArray([
             'parent_id',
-            'virtual.abc',
             'nested.parent_id',
-            'nested.virtual',
         ], [
             'virtual',
         ]);
@@ -237,10 +255,83 @@ final class CollectionTest extends TestCase {
             'parent_id' => 111,
             'virtual' => [
                 'abc' => '123',
+                'def' => '456',
             ],
             'nested' => [
                 'parent_id' => 222,
-                // missing because not in extras.
+                // Missing because not in extras.
+            ],
+        ];
+
+        $this->assertEquals($expected, $array);
+
+        // nested extras.
+        $array = $thingo->toArray([
+            'parent_id',
+            'nested.parent_id',
+        ], [
+            'virtual',
+            'nested.virtual',
+        ]);
+
+        $expected = [
+            'parent_id' => 111,
+            'virtual' => [
+                'abc' => '123',
+                'def' => '456',
+            ],
+            'nested' => [
+                'parent_id' => 222,
+                'virtual' => [
+                    'abc' => '123',
+                    'def' => '456',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $array);
+
+        // filtering on extras.
+        $array = $thingo->toArray([
+            'parent_id',
+            'virtual.abc',
+        ], [
+            'virtual',
+            'nested.virtual',
+        ]);
+
+        $expected = [
+            'parent_id' => 111,
+            'virtual' => [
+                'abc' => '123',
+            ],
+            'nested' => [
+                'virtual' => [
+                    'abc' => '123',
+                    'def' => '456',
+                ],
+            ]
+        ];
+
+        $this->assertEquals($expected, $array);
+
+        // alternate filtering on extras.
+        $array = $thingo->toArray([
+            'parent_id',
+        ], [
+            'virtual.abc',
+            'nested.virtual.def',
+        ]);
+
+        $expected = [
+            'parent_id' => 111,
+            'virtual' => [
+                'abc' => '123',
+            ],
+            'nested' => [
+                'virtual' => [
+                    'def' => '123',
+                ],
             ]
         ];
 
@@ -249,9 +340,7 @@ final class CollectionTest extends TestCase {
         // wildcard extras.
         $array = $thingo->toArray([
             'parent_id',
-            'virtual.abc',
             'nested.parent_id',
-            'nested.virtual',
         ], [
             '*.virtual',
         ]);
@@ -271,7 +360,29 @@ final class CollectionTest extends TestCase {
         ];
 
         $this->assertEquals($expected, $array);
+
+        // filtering wildcards
+        $array = $thingo->toArray([
+            'parent_id',
+        ], [
+            '*.virtual.def',
+        ]);
+
+        $expected = [
+            'parent_id' => 111,
+            'virtual' => [
+                'def' => '456',
+            ],
+            'nested' => [
+                'virtual' => [
+                    'def' => '456',
+                ],
+            ]
+        ];
+
+        $this->assertEquals($expected, $array);
     }
+
 
     public function testIterator() {
         $thingo = new Thingo([

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -108,6 +108,171 @@ final class CollectionTest extends TestCase {
     }
 
 
+    public function testNestedFields() {
+        $thingo = new ThingoFields([
+            'parent_id' => 111,
+            'description' => 'blah blah blah',
+            'empty' => [
+                'lies' => 'and more lies',
+                'description' => 'test',
+            ],
+            'nested' => new ThingoFields([
+                'parent_id' => 222,
+                'description' => 'etc',
+                'empty' => [
+                    'lies' => 'not these ones',
+                    'description' => 'eyy',
+                ],
+            ])
+        ]);
+
+        $array = $thingo->toArray(['empty.lies']);
+
+        $expected = ['empty' => ['lies' => 'and more lies']];
+        $this->assertEquals($expected, $array);
+
+        // Precise fields.
+        $array = $thingo->toArray([
+            'description',
+            'empty.description',
+            'nested.description',
+            'nested.empty.description',
+        ]);
+
+        $expected = [
+            'description' => 'blah blah blah',
+            'empty' => ['description' => 'test'],
+            'nested' => [
+                'description' => 'etc',
+                'empty' => ['description' => 'eyy'],
+            ],
+        ];
+        $this->assertEquals($expected, $array);
+
+        // a single thing.
+        $array = $thingo->toArray([
+            'empty',
+        ]);
+
+        $expected = [
+            'empty' => [
+                'lies' => 'and more lies',
+                'description' => 'test',
+            ],
+        ];
+        $this->assertEquals($expected, $array);
+
+        // a few things.
+        $array = $thingo->toArray([
+            'empty',
+            'nested',
+        ]);
+
+        $expected = [
+            'empty' => [
+                'lies' => 'and more lies',
+                'description' => 'test',
+            ],
+            'nested' => [
+                'empty' => [
+                    'lies' => 'not these ones',
+                    'description' => 'eyy',
+                ],
+                'id' => 1,
+                'parent_id' => 222,
+                'description' => 'etc',
+                'thing' => '1234567890',
+            ],
+        ];
+        $this->assertEquals($expected, $array);
+
+        // a single nested thing.
+        $array = $thingo->toArray([
+            'nested.empty',
+        ]);
+
+        $expected = [
+            'nested' => [
+                'empty' => [
+                    'lies' => 'not these ones',
+                    'description' => 'eyy',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $array);
+
+        // lots of things.
+        $array = $thingo->toArray([
+            'parent_id',
+            'empty',
+            'nested.empty',
+        ]);
+
+        $expected = [
+            'parent_id' => 111,
+            'empty' => [
+                'lies' => 'and more lies',
+                'description' => 'test',
+            ],
+            'nested' => [
+                'empty' => [
+                    'lies' => 'not these ones',
+                    'description' => 'eyy',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $array);
+
+        // filtering on extras.
+        $array = $thingo->toArray([
+            'parent_id',
+            'virtual.abc',
+            'nested.parent_id',
+            'nested.virtual',
+        ], [
+            'virtual',
+        ]);
+
+        $expected = [
+            'parent_id' => 111,
+            'virtual' => [
+                'abc' => '123',
+            ],
+            'nested' => [
+                'parent_id' => 222,
+                // missing because not in extras.
+            ]
+        ];
+
+        $this->assertEquals($expected, $array);
+
+        // wildcard extras.
+        $array = $thingo->toArray([
+            'parent_id',
+            'virtual.abc',
+            'nested.parent_id',
+            'nested.virtual',
+        ], [
+            '*.virtual',
+        ]);
+
+        $expected = [
+            'parent_id' => 111,
+            'virtual' => [
+                'abc' => '123',
+            ],
+            'nested' => [
+                'parent_id' => 222,
+                'virtual' => [
+                    'abc' => '123',
+                    'def' => '456',
+                ],
+            ]
+        ];
+
+        $this->assertEquals($expected, $array);
+    }
+
     public function testIterator() {
         $thingo = new Thingo([
             'parent_id' => 123,
@@ -307,6 +472,9 @@ class ThingoFields extends Thingo
     /** @var string */
     public $key = 'kinda-secret';
 
+    /** @var Thingo|null */
+    public $nested;
+
 
     public function fields(): array
     {
@@ -323,6 +491,12 @@ class ThingoFields extends Thingo
             'more_things' => function() {
                 return ['a', 'b', 'c'];
             },
+            'virtual' => function() {
+                return [
+                    'abc' => '123',
+                    'def' => '456',
+                ];
+            }
         ];
     }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -78,6 +78,7 @@ final class CollectionTest extends TestCase {
             'empty' => null,
         ]);
 
+        // Default output.
         $array = $thingo->toArray();
 
         $this->assertEquals(1, $array['id']);
@@ -87,12 +88,14 @@ final class CollectionTest extends TestCase {
 
         $this->assertEquals($thingo->getVirtualThing(), $array['thing']);
 
+        // Standard filtering.
         $array = $thingo->toArray(['id', 'description']);
 
         $this->assertArrayNotHasKey('empty', $array);
         $this->assertArrayNotHasKey('name', $array);
         $this->assertArrayNotHasKey('key', $array);
 
+        // A virtual extra field.
         $array = $thingo->toArray(null, ['more_things']);
 
         $this->assertArrayHasKey('id', $array);
@@ -105,6 +108,22 @@ final class CollectionTest extends TestCase {
 
         $expected = ['a', 'b', 'c'];
         $this->assertEquals($expected, $array['more_things']);
+
+        // A field excluded by fields().
+        $array = $thingo->toArray(null, ['key']);
+
+        $this->assertArrayHasKey('id', $array);
+        $this->assertArrayHasKey('key', $array);
+        $this->assertArrayNotHasKey('more_things', $array);
+
+        // This also works without ArrayableFields.
+        $thing = new Thingo();
+
+        $array = $thing->toArray();
+        $this->assertArrayNotHasKey('hidden', $array);
+
+        $array = $thing->toArray(null, ['hidden']);
+        $this->assertArrayHasKey('hidden', $array);
     }
 
 
@@ -418,6 +437,7 @@ final class CollectionTest extends TestCase {
             ['name', null],
             ['description', 'blah blah blah'],
             ['empty', null],
+            ['hidden', 'nope'],
         ];
 
         $this->assertEquals($expected, $items);
@@ -550,11 +570,14 @@ class Thingo extends Collection {
     /** @var array */
     public $empty = [];
 
+    public $hidden = 'nope';
+
 
     public function fields(): array
     {
         return [
             'thing' => [$this, 'getVirtualThing'],
+            'hidden' => false,
         ];
     }
 
@@ -592,6 +615,7 @@ class ThingoFields extends Thingo
         $fields = Collection::fields();
         $fields['thing'] = [$this, 'getVirtualThing'];
         $fields['key'] = false;
+        $fields['hidden'] = false;
         return $fields;
     }
 

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -349,17 +349,36 @@ final class CollectionTest extends TestCase {
             ],
             'nested' => [
                 'virtual' => [
-                    'def' => '123',
+                    'def' => '456',
                 ],
             ]
         ];
 
         $this->assertEquals($expected, $array);
+    }
+
+
+    public function testExtraWildcards() {
+        $thingo = new ThingoFields([
+            'parent_id' => 111,
+            'description' => 'blah blah blah',
+            'empty' => [
+                'lies' => 'and more lies',
+                'description' => 'test',
+            ],
+            'nested' => new ThingoFields([
+                'parent_id' => 222,
+                'description' => 'etc',
+                'empty' => [
+                    'lies' => 'not these ones',
+                    'description' => 'eyy',
+                ],
+            ])
+        ]);
 
         // wildcard extras.
         $array = $thingo->toArray([
             'parent_id',
-            'nested.parent_id',
         ], [
             '*.virtual',
         ]);
@@ -368,9 +387,9 @@ final class CollectionTest extends TestCase {
             'parent_id' => 111,
             'virtual' => [
                 'abc' => '123',
+                'def' => '456',
             ],
             'nested' => [
-                'parent_id' => 222,
                 'virtual' => [
                     'abc' => '123',
                     'def' => '456',


### PR DESCRIPTION
## A preface

- `Arrayable` introduces the `toArray()` method for objects to convert into JSON-ish objects.
- `ArrayableFields` adds filtering and optional 'extra' fields.

This PR introduces _deep_ filtering of child items to `ArrayableFields` as well as filtering to the generic `Arrays::toArray()` helper.

## An example

A tree like:

```
root
   => field1
   => field2
   => child1
   => child2 => [deep1]
   => child3 => [deep2, deep3]
```

Now `toArray()` will give you all the fields of the root and of every child - with respect to the `fields()` config of each object.

Filtering exists already, but was limited to the root object. So although one can restrict whole fields/children the entire array conversion of each 'child' field is included if specified. In the example above, one couldn't get only `deep2` without also getting `deep3`.

So we've introduced this syntax:
```php
$root->toArray(['field1', 'child3.deep2' ]);
```

Which produces this:

```php
[
  'field1' => 'test',
  'child3' => [ 'deep2' => 'test' ],
]
```


## Extra fields

Extra fields are things not included in the standard output of the `fields()` config, perhaps they're too big, or they're expensive to compute. One can 'add' these to their output using the 2nd parameter:

```php
$root->toArray(null, ['extra1']);
```

But again, we're restricted to _full_ objects and only the extra fields of the root item. The filtering updates from fields also resolve this.

```php
$root->toArray(null, ['extra1.name']);
```

At times we will also want to indiscriminately get an extra field from _all_ items in the tree.

```php
$root->toArray(null, ['*.extra1']);
```


## Draft because

My tests are still broken for wildcards :(