### PR TITLE
Feat/time month year opts

### DIFF
--- a/src/Time.php
+++ b/src/Time.php
@@ -670,4 +670,30 @@ class Time
 
         return $days;
     }
+
+
+    /**
+     * Get a list of month options for a dropdown as month_num => name
+     *
+     * @param int $length substring length
+     * @param string $format date format AS per DateTime::format
+     * @param int $day day of the month, useful if using a day in the format
+     * @return string[]
+     */
+    public static function monthOptions(int $length = 9, string $format = 'F', int $day = 1)
+    {
+        $options = [];
+
+        for ($i = 1; $i <= 12; $i++) {
+            $num = str_pad((string) $i, 2, '0', STR_PAD_LEFT);
+
+            $name = date($format, mktime(0, 0, 0, $i, $day));
+            $name = substr($name, 0, $length);
+
+            $options[$num] = $name;
+        }
+
+        return $options;
+    }
+
 }

--- a/src/Time.php
+++ b/src/Time.php
@@ -696,4 +696,25 @@ class Time
         return $options;
     }
 
+
+    /**
+     * List of years (starting from this year).
+     *
+     * @param int $length number of years to include
+     * @return int[]
+     */
+    public static function years(int $length = 5): array
+    {
+        $years = [];
+
+        $now = new DateTimeImmutable();
+        $year = (int) $now->format('Y');
+
+        for ($i = $year - $length; $i <= $year + $length; $i++) {
+            $years[$i] = $i;
+        }
+
+        return $years;
+    }
+
 }


### PR DESCRIPTION
A couple of handy helpers for month and year lists.

Some useful formatting bits.

Unfortunately the `months` method already exists but so does `weeks` so the naming convention is imperfect here..