### PR TITLE
Feat/arrayable nulls

### DIFF
--- a/src/ArrayableTrait.php
+++ b/src/ArrayableTrait.php
@@ -111,9 +111,10 @@ trait ArrayableTrait
      *
      * @param string[]|null $filter
      * @param string[]|null $extra
+     * @param bool $nulls - include null fields in the output
      * @return array
      */
-    public function toArray(array $filter = null, array $extra = null): array
+    public function toArray(array $filter = null, array $extra = null, bool $nulls = false): array
     {
         if ($this instanceof ArrayableFields) {
             $fields = $this->fields();
@@ -168,8 +169,8 @@ trait ArrayableTrait
             if ($item === true) {
                 $item = $this->$key ?? null;
 
-                // Keep skipping null fields for compatibility.
-                if ($item === null) {
+                // 'No nulls' by default for compatibility.
+                if ($item === null and !$nulls) {
                     continue;
                 }
             }
@@ -193,8 +194,16 @@ trait ArrayableTrait
                 continue;
             }
 
-            // Recurse into nested arrayables.
+            // Recurse + pass through null flags.
             if (
+                $this instanceof ArrayableFields
+                and $item instanceof ArrayableFields
+            ) {
+                $item = $item->toArray(null, null, $nulls);
+            }
+
+            // Recurse into nested arrays or arrayables.
+            else if (
                 is_array($item)
                 or $item instanceof Arrayable
                 or $item instanceof Traversable

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -83,6 +83,7 @@ final class CollectionTest extends TestCase {
         $this->assertEquals(1, $array['id']);
         $this->assertEquals(123, $array['parent_id']);
         $this->assertEquals('blah blah blah', $array['description']);
+        $this->assertArrayNotHasKey('empty', $array);
         $this->assertArrayNotHasKey('key', $array);
 
         $this->assertEquals($thingo->getVirtualThing(), $array['thing']);
@@ -105,6 +106,23 @@ final class CollectionTest extends TestCase {
 
         $expected = ['a', 'b', 'c'];
         $this->assertEquals($expected, $array['more_things']);
+    }
+
+
+    public function testArrayableFieldsNulls() {
+        $thingo = new ThingoFields([
+            'parent_id' => 123,
+            'description' => 'blah blah blah',
+            'empty' => null,
+        ]);
+
+        $array = $thingo->toArray(null, null, true);
+
+        $this->assertEquals(1, $array['id']);
+        $this->assertEquals(123, $array['parent_id']);
+        $this->assertEquals('blah blah blah', $array['description']);
+        $this->assertEquals(null, $array['empty']);
+        $this->assertArrayNotHasKey('key', $array);
     }
 
 


### PR DESCRIPTION
Include null values in array bodies.

Pretty simple stuff - however, recursing into nested objects requires that they implement ArrayableFields. Still, any class (regardless of the interface) that uses the ArryableTrait will still get the null parameter/behaviour on the root object.