### PR TITLE
Caching encrypt instances by configs

### DIFF
--- a/src/Encrypt.php
+++ b/src/Encrypt.php
@@ -27,14 +27,15 @@ class Encrypt implements EncryptInterface
      */
     public static function instance(array $config = []): Encrypt
     {
-        static $instance = null;
+        static $instances = [];
+        $config_hash = md5(json_encode($config));
 
         // Create the singleton
-        if ($instance === null) {
-            $instance = new Encrypt($config);
+        if (!isset($instances[$config_hash])) {
+            $instances[$config_hash] = new Encrypt($config);
         }
 
-        return $instance;
+        return $instances[$config_hash];
     }
 
 

--- a/src/Encrypt.php
+++ b/src/Encrypt.php
@@ -28,7 +28,11 @@ class Encrypt implements EncryptInterface
     public static function instance(array $config = []): Encrypt
     {
         static $instances = [];
-        $config_hash = md5(json_encode($config));
+
+        // Sort by key to ensure consistent hash
+        $sorted_config = $config;
+        ksort($sorted_config);
+        $config_hash = hash('sha256', json_encode($sorted_config));
 
         // Create the singleton
         if (!isset($instances[$config_hash])) {


### PR DESCRIPTION
Otherwise, if a loop uses Encrypt::instance
The config in the first iteration gets locked in
So if iterating objects with their own encrypt setups it just breaks down

This preserves the caching behaviour but allows multiple configs

Not tested in here, but have done a similar thing in another 
encrypt class to solve this issue