### PR TITLE
Support loading JSON data into a model as an array property

### DIFF
--- a/src/UpdateTrait.php
+++ b/src/UpdateTrait.php
@@ -7,6 +7,7 @@
 namespace karmabunny\kb;
 
 use JsonException;
+use ReflectionNamedType;
 use ReflectionProperty;
 
 /**
@@ -29,8 +30,7 @@ trait UpdateTrait
     protected function convertJsonItem(string $key, mixed &$item): void
     {
         $type = (new ReflectionProperty($this, $key))->getType();
-        // TODO: use $type?->getName() once required PHP is >= 8.0
-        if (is_array($item) || $type === null || $type->getName() !== 'array') {
+        if (is_array($item) || (!$type instanceof ReflectionNamedType) || $type->getName() !== 'array') {
             return;
         }
 


### PR DESCRIPTION
E.g.

```php
class MyModel extends \Sprout\Helpers\Model
{
    public ?int $id;
    // array types saved in MySQL JSON columns
    public array $some_array;
    public array $other_array;
}

$model = new MyModel();
$model->some_array = ['check', 1, 2];
$model->other_array = ["works" => true, "fails" => false];

$model->save();

MyModel::findAll();
```