### PR TITLE
Feat/event sender

### DIFF
--- a/src/EventableTrait.php
+++ b/src/EventableTrait.php
@@ -50,7 +50,7 @@ trait EventableTrait
             throw new InvalidArgumentException("Object {$self} is not a subclass of {$class}");
         }
 
-        $class ??= $this;
+        $class = $class ?? $this;
 
         if ($event instanceof Event) {
             $event->sender = $this;

--- a/src/EventableTrait.php
+++ b/src/EventableTrait.php
@@ -30,9 +30,9 @@ trait EventableTrait
      * ```
      * // Good
      * this->trigger(MyClass::class, $event);
+     * $this->trigger(self::class, $event);
      *
      * // Beware
-     * $this->trigger(self::class, $event);
      * $this->trigger(static::class, $event);
      * $this->trigger(get_class($this), $event);
      * ```

--- a/src/EventableTrait.php
+++ b/src/EventableTrait.php
@@ -38,16 +38,19 @@ trait EventableTrait
      * ```
      *
      * @see Events::trigger()
+     * @param class-string|null $class
      * @param EventInterface $event
      * @param bool $once Don't trigger if the event has already run at least once.
      * @return array handler results
      */
-    protected function trigger(string $class, EventInterface $event, bool $once = false): array
+    protected function trigger(?string $class, EventInterface $event, bool $once = false): array
     {
-        if (!is_a($this, $class, true)) {
+        if ($class and !is_a($this, $class, true)) {
             $self = get_class($this);
             throw new InvalidArgumentException("Object {$self} is not a subclass of {$class}");
         }
+
+        $class ??= $this;
 
         if ($event instanceof Event) {
             $event->sender = $this;
@@ -79,6 +82,6 @@ trait EventableTrait
         // Unlike trigger, using dynamic class names here is OK. A user is not
         // surprised (hopefully) that they only receive events appropriate for
         // the leaf node that is 'this'.
-        Events::on(static::class, $event, $fn, $append);
+        Events::on($this, $event, $fn, $append);
     }
 }

--- a/src/EventableTrait.php
+++ b/src/EventableTrait.php
@@ -44,6 +44,11 @@ trait EventableTrait
      */
     protected function trigger(string $class, EventInterface $event, bool $once = false): array
     {
+        if (!is_a($this, $class, true)) {
+            $self = get_class($this);
+            throw new InvalidArgumentException("Object {$self} is not a subclass of {$class}");
+        }
+
         if ($event instanceof Event) {
             $event->sender = $this;
         }

--- a/src/Events.php
+++ b/src/Events.php
@@ -192,6 +192,14 @@ class Events
         }
 
         if (is_object($sender)) {
+            if (is_subclass_of($event, Event::class)) {
+                $fn = function(Event $event) use ($sender, $fn) {
+                    if ($event->sender === $sender) {
+                        return $fn($event);
+                    }
+                };
+            }
+
             $sender = get_class($sender);
         }
 

--- a/src/Events.php
+++ b/src/Events.php
@@ -65,7 +65,7 @@ class Events
      * Triggering events in a class that is not it's own, or even from
      * a parent class is _strongly_ discouraged.
      *
-     * _Don't_ use dynamic class names, such as:
+     * Avoid dynamic class names, such as:
      * - `static::class`
      * - `get_class($this)`
      *
@@ -127,7 +127,7 @@ class Events
     /**
      * Listen to an event.
      *
-     * This method has two signatures:
+     * This method has two key signatures:
      *
      * ```
      * // Full form
@@ -139,6 +139,11 @@ class Events
      *
      * In the second form the event type is derived from the first parameter
      * of the handler function.
+     *
+     * All invocations accept the `$sender` as an object or string. Given a
+     * object instance the sender is attached to the event. This then automatically
+     * filters events on that sender to the appropriate instance. Filtering is
+     * not applied to `EventInterface` objects not extending `Event`.
      *
      * @param class-string|object $sender
      * @param class-string<EventInterface>|callable $event

--- a/src/Events.php
+++ b/src/Events.php
@@ -102,6 +102,10 @@ class Events
         // Fire off.
         foreach ($handlers as $fn) {
             $results[] = $fn($event);
+
+            if ($event instanceof Event and $event->handled) {
+                break;
+            }
         }
 
         if (self::$_log !== null) {

--- a/src/Events.php
+++ b/src/Events.php
@@ -69,14 +69,20 @@ class Events
      * - `static::class`
      * - `get_class($this)`
      *
-     * @param class-string $sender
+     * @param class-string|object $sender
      * @param EventInterface $event
      * @param bool $once Don't trigger if the event has already run at least once.
      * @return array[] event results.
      */
-    public static function trigger(string $sender, EventInterface $event, bool $once = false): array
+    public static function trigger($sender, EventInterface $event, bool $once = false): array
     {
         // Events are ID'd by their full namespaced class name.
+        if (is_object($sender)) {
+            if ($event instanceof Event) {
+                $event->sender = $sender;
+            }
+            $sender = get_class($sender);
+        }
 
         if ($once) {
             if (isset(self::$_run[$sender][get_class($event)])) {
@@ -134,14 +140,14 @@ class Events
      * In the second form the event type is derived from the first parameter
      * of the handler function.
      *
-     * @param class-string $sender
+     * @param class-string|object $sender
      * @param class-string<EventInterface>|callable $event
      * @param callable|bool|null $fn
      * @param bool $append
      * @return void
      * @throws InvalidArgumentException
      */
-    public static function on(string $sender, $event, $fn = null, bool $append = true)
+    public static function on($sender, $event, $fn = null, bool $append = true)
     {
         // If no handler is given, assume the second parameter is handler.
         // Using some cheeky reflection we can extract the event type.
@@ -185,6 +191,10 @@ class Events
             throw new InvalidArgumentException("Event '{$event}' is not an EventInterface");
         }
 
+        if (is_object($sender)) {
+            $sender = get_class($sender);
+        }
+
         if (!$append and isset(self::$_events[$sender][$event])) {
             array_unshift(self::$_events[$sender][$event], $fn);
         }
@@ -203,12 +213,16 @@ class Events
      *
      * Or both `null, null` to remove _all_ listeners from all senders.
      *
-     * @param class-string|null $sender
+     * @param class-string|object|null $sender
      * @param class-string<EventInterface>|null $event
      * @return void
      */
-    public static function off(?string $sender, ?string $event = null)
+    public static function off($sender, ?string $event = null)
     {
+        if (is_object($sender)) {
+            $sender = get_class($sender);
+        }
+
         if ($sender === null) {
             if ($event) {
                 foreach (array_keys(self::$_events) as $sender) {

--- a/src/Events.php
+++ b/src/Events.php
@@ -202,7 +202,7 @@ class Events
         }
 
         if (is_object($sender)) {
-            if (is_subclass_of($event, Event::class)) {
+            if (is_a($event, Event::class, true)) {
                 $fn = function(Event $event) use ($sender, $fn) {
                     if ($event->sender === $sender) {
                         return $fn($event);

--- a/src/Events.php
+++ b/src/Events.php
@@ -84,6 +84,11 @@ class Events
             $sender = get_class($sender);
         }
 
+        // @phpstan-ignore-next-line: runtime check.
+        if (!is_string($sender) or !class_exists($sender)) {
+            throw new InvalidArgumentException("Sender '{$sender}' is not a class");
+        }
+
         if ($once) {
             if (isset(self::$_run[$sender][get_class($event)])) {
                 return [];

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -557,6 +557,34 @@ class EventTest extends TestCase
         $this->assertEquals(2, $count);
         $this->assertCount(0, $actual);
     }
+
+
+    public function testEventSender()
+    {
+        $root1 = new RootEmitter();
+        $root2 = new RootEmitter();
+
+        $events = [];
+
+        $root1->on(function(TestEvent $event) use (&$events) {
+            $events[] = $event;
+        });
+
+        $root2->on(function(TestEvent $event) use (&$events) {
+            $events[] = $event;
+        });
+
+        $root1->testDynamic();
+        $root2->testDynamic();
+
+        $this->assertCount(2, $events);
+
+        $this->assertEquals(spl_object_id($root1), spl_object_id($events[0]->sender));
+        $this->assertNotEquals(spl_object_id($root1), spl_object_id($events[1]->sender));
+
+        $this->assertNotEquals(spl_object_id($root2), spl_object_id($events[0]->sender));
+        $this->assertEquals(spl_object_id($root2), spl_object_id($events[1]->sender));
+    }
 }
 
 

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -608,7 +608,7 @@ class RootEmitter
     public function testDynamic(): array
     {
         $event = new TestEvent();
-        $results = $this->trigger(get_class($this), $event);
+        $results = $this->trigger(null, $event);
         return $results;
     }
 }

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -121,36 +121,31 @@ class EventTest extends TestCase
     public function testHandled()
     {
         Events::on(RootEmitter::class, function(TestEvent $event) {
-            if ($event->handled) return;
             return 'one';
         });
 
         Events::on(RootEmitter::class, function(TestEvent $event) {
-            if ($event->handled) return;
             return 'two';
         });
 
         Events::on(RootEmitter::class, function(TestEvent $event) {
-            if ($event->handled) return;
             $event->handled = true;
             return 'three';
         }, false);
 
         Events::on(RootEmitter::class, function(TestEvent $event) {
-            if ($event->handled) return;
             return 'four';
         }, false);
 
         Events::on(RootEmitter::class, function(TestEvent $event) {
-            if ($event->handled) return;
             return 'five';
         }, true);
 
         $event = new TestEvent();
         $actual = Events::trigger(RootEmitter::class, $event);
 
-        $this->assertCount(5, $actual);
-        $this->assertEquals(['four', 'three', null, null, null], $actual);
+        $this->assertCount(2, $actual);
+        $this->assertEquals(['four', 'three'], $actual);
     }
 
 


### PR DESCRIPTION
The event system was a little rushed when we first wrote it. This polishes a few part of the events system that should have been done long ago.

Events are largely emitted from static interfaces, which makes the `sender` property a bit weird and the `EventableTrait` rather misleading for a few behaviours. In particularly using `$inst->on(...)` would receive events from _other_ instances which is very odd (and annoying).

Events could also be triggered for _other_ classes by using `$this->trigger(OtherClass::class)` which is clearly incorrect usage.

The `handled` property was odd. It's baked into the base event class but requires each handler to check? Very silly. This is probably the most likely breaking change in this PR.

Whereas the rest of the changes are bugfixes because no-one should be expecting those behaviours to work as they were. If their workflow break? Well good.