### PR TITLE
Fix: overzealous detection of passwords in URLs

### DIFF
--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -38,7 +38,7 @@ class Secrets extends DataObject
     const RULE_KEY_CVV = '(?i:cvv|cvn|ccv)';
 
     const RULE_HTTP_AUTH = '^(?i:basic|bearer)\w(.*)';
-    const RULE_HTTP_INLINE = ':\/\/[^:]+:[^@]+@';
+    const RULE_HTTP_INLINE = ':\/\/[^:\/]+:[^@\/]+@';
     const RULE_JWT = '^eyJ[^.]+\..';
     const RULE_SSH_PGP = '^BEGIN.*PRIVATE KEY';
     const RULE_BYCRYPT_HASH = '^\$2[aby]\$.*\$';


### PR DESCRIPTION
E.g. `<link href="https://fonts.googleapis.com/css2?family=FontyMcFontFace:wght@300;400;500;700;800" rel="stylesheet">`

Usernames and passwords should be URL-encoded, so if either has a slash, it should be encoded as `%2F` and therefore not match this pattern